### PR TITLE
Add scramble generator and wire into interactive playground

### DIFF
--- a/apps/web/src/features/cube/components/ActionBar.tsx
+++ b/apps/web/src/features/cube/components/ActionBar.tsx
@@ -24,7 +24,10 @@ export const ActionBar = ({ moveCount, onReset, onScramble }: ActionBarProps) =>
       Reset
     </button>
     {moveCount > 0 ? (
-      <output className='badge badge-neutral badge-sm md:badge-md' aria-live='polite'>
+      <output
+        className='badge badge-neutral badge-sm md:badge-md whitespace-nowrap'
+        aria-live='polite'
+      >
         {moveCount} {moveCount === 1 ? 'move' : 'moves'}
       </output>
     ) : null}

--- a/apps/web/src/features/cube/components/CubeNet.tsx
+++ b/apps/web/src/features/cube/components/CubeNet.tsx
@@ -4,10 +4,11 @@ import { FaceGrid } from '~/features/cube/components/FaceGrid'
 
 interface CubeNetProps {
   stickersByFace: StickersByFace
+  className?: string
 }
 
-export const CubeNet = ({ stickersByFace }: CubeNetProps) => (
-  <section className='card bg-base-200 shadow-lg' aria-label='Cube state'>
+export const CubeNet = ({ stickersByFace, className = '' }: CubeNetProps) => (
+  <section className={`card bg-base-200 shadow-lg ${className}`} aria-label='Cube state'>
     <div className='card-body grid grid-cols-4 grid-rows-3 place-items-center gap-4 p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8'>
       <FaceGrid stickers={stickersByFace.U} label='U' className='col-start-2 row-start-1' />
       <FaceGrid stickers={stickersByFace.D} label='D' className='col-start-2 row-start-3' />

--- a/apps/web/src/features/cube/components/CubePlayground.spec.tsx
+++ b/apps/web/src/features/cube/components/CubePlayground.spec.tsx
@@ -47,11 +47,11 @@ describe('CubePlayground', () => {
     expect(stickersAfter).not.toEqual(stickersBefore)
   })
 
-  it('should render Reset but not Scramble', () => {
+  it('should render Reset and Scramble buttons', () => {
     render(<CubePlayground />)
 
     expect(screen.getByRole('button', { name: 'Reset' })).toBeDefined()
-    expect(screen.queryByRole('button', { name: 'Scramble' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Scramble' })).toBeDefined()
   })
 
   it('should render empty move history', () => {
@@ -81,5 +81,29 @@ describe('CubePlayground', () => {
 
     expect(screen.getByText('No moves yet')).toBeDefined()
     expect(screen.queryByText(/moves$/)).toBeNull()
+  })
+
+  it('should show 20 history tokens after Scramble', async () => {
+    const user = userEvent.setup()
+
+    render(<CubePlayground />)
+
+    await user.click(screen.getByRole('button', { name: 'Scramble' }))
+
+    const history = screen.getByLabelText('Move history')
+
+    expect(history.querySelectorAll('.badge')).toHaveLength(20)
+    expect(screen.getByText('20 moves')).toBeDefined()
+  })
+
+  it('should return to solved after Scramble then Reset', async () => {
+    const user = userEvent.setup()
+
+    render(<CubePlayground />)
+
+    await user.click(screen.getByRole('button', { name: 'Scramble' }))
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
+
+    expect(screen.getByText('No moves yet')).toBeDefined()
   })
 })

--- a/apps/web/src/features/cube/components/CubePlayground.tsx
+++ b/apps/web/src/features/cube/components/CubePlayground.tsx
@@ -5,6 +5,7 @@ import { MoveHistory } from '~/features/cube/components/MoveHistory'
 import {
   applyMoveAction,
   resetAction,
+  scrambleAction,
   useMoveHistory,
   useStickersByFace
 } from '~/features/cube/stores/cube-store'
@@ -14,24 +15,25 @@ export const CubePlayground = () => {
   const moveHistory = useMoveHistory()
 
   return (
-    <section className='space-y-6' aria-label='Interactive cube'>
-      <div className='flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-8'>
-        <CubeNet stickersByFace={stickersByFace} />
-        <aside className='card bg-base-200 flex-1 shadow-lg'>
-          <div className='card-body gap-5 p-4 md:p-6'>
-            <MoveControls onMove={applyMoveAction} />
-            <div className='border-base-300 border-t pt-4'>
-              <ActionBar moveCount={moveHistory.length} onReset={resetAction} />
-            </div>
-            <div className='border-base-300 border-t pt-4'>
-              <h3 className='text-base-content/60 mb-2 text-xs font-semibold tracking-widest uppercase'>
-                History
-              </h3>
-              <MoveHistory moves={moveHistory} />
-            </div>
-          </div>
-        </aside>
-      </div>
+    <section
+      className='flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-8'
+      aria-label='Interactive cube'
+    >
+      <CubeNet stickersByFace={stickersByFace} />
+      <aside className='card bg-base-200 flex-1 shadow-lg'>
+        <section className='card-body gap-5 p-4 md:p-6'>
+          <MoveControls onMove={applyMoveAction} />
+          <ActionBar
+            moveCount={moveHistory.length}
+            onReset={resetAction}
+            onScramble={scrambleAction}
+          />
+          <h3 className='text-base-content/60 text-xs font-semibold tracking-widest uppercase'>
+            History
+          </h3>
+          <MoveHistory moves={moveHistory} />
+        </section>
+      </aside>
     </section>
   )
 }

--- a/apps/web/src/features/cube/components/CubePlayground.tsx
+++ b/apps/web/src/features/cube/components/CubePlayground.tsx
@@ -21,7 +21,10 @@ export const CubePlayground = () => {
     >
       <CubeNet stickersByFace={stickersByFace} />
       <aside className='card bg-base-200 flex-1 shadow-lg'>
-        <section className='card-body gap-5 p-4 md:p-6'>
+        <section className='card-body gap-5 p-4 md:p-6' aria-label='Cube controls'>
+          <h3 className='text-base-content/60 text-xs font-semibold tracking-widest uppercase'>
+            Controls
+          </h3>
           <MoveControls onMove={applyMoveAction} />
           <ActionBar
             moveCount={moveHistory.length}

--- a/apps/web/src/features/cube/components/FaceGrid.tsx
+++ b/apps/web/src/features/cube/components/FaceGrid.tsx
@@ -33,16 +33,16 @@ export const FaceGrid = ({ stickers, label, className = '' }: FaceGridProps) => 
         </figcaption>
       ) : null}
 
-      <div className='bg-base-300 ring-base-content/20 grid size-20 grid-cols-3 gap-1 rounded-sm p-1 ring-1 md:size-28 lg:size-36'>
+      <ul className='bg-base-300 ring-base-content/20 grid size-20 grid-cols-3 gap-1 rounded-sm p-1 ring-1 md:size-28 lg:size-36'>
         {stickers.slice(0, 9).map((color, index) => (
-          <span
+          <li
             key={index}
             role='img'
             aria-label={colorNameByCode[color]}
             className={`ring-base-content/10 hover:shadow-primary/20 aspect-square rounded-xs ring-1 transition-shadow hover:shadow-md ${stickerClassByColor[color]}`}
           />
         ))}
-      </div>
+      </ul>
     </figure>
   )
 }

--- a/apps/web/src/features/cube/components/FaceGrid.tsx
+++ b/apps/web/src/features/cube/components/FaceGrid.tsx
@@ -37,10 +37,10 @@ export const FaceGrid = ({ stickers, label, className = '' }: FaceGridProps) => 
         {stickers.slice(0, 9).map((color, index) => (
           <li
             key={index}
-            role='img'
-            aria-label={colorNameByCode[color]}
             className={`ring-base-content/10 hover:shadow-primary/20 aspect-square rounded-xs ring-1 transition-shadow hover:shadow-md ${stickerClassByColor[color]}`}
-          />
+          >
+            <span role='img' aria-label={colorNameByCode[color]} className='block size-full' />
+          </li>
         ))}
       </ul>
     </figure>

--- a/apps/web/src/features/cube/stores/cube-store.spec.ts
+++ b/apps/web/src/features/cube/stores/cube-store.spec.ts
@@ -6,7 +6,8 @@ import {
   $moveHistory,
   $stickersByFace,
   applyMoveAction,
-  resetAction
+  resetAction,
+  scrambleAction
 } from '~/features/cube/stores/cube-store'
 
 beforeEach(() => {
@@ -68,5 +69,24 @@ describe('cube-store', () => {
     resetAction()
 
     expect($moveHistory.get()).toEqual([])
+  })
+
+  it('should produce non-solved state on scramble', () => {
+    scrambleAction()
+
+    expect($cubeState.get()).not.toEqual(createSolvedState())
+  })
+
+  it('should set 20-move history on scramble', () => {
+    scrambleAction()
+
+    expect($moveHistory.get()).toHaveLength(20)
+  })
+
+  it('should replace existing history on scramble', () => {
+    applyMoveAction('R')
+    scrambleAction()
+
+    expect($moveHistory.get()).toHaveLength(20)
   })
 })

--- a/apps/web/src/features/cube/stores/cube-store.ts
+++ b/apps/web/src/features/cube/stores/cube-store.ts
@@ -1,6 +1,12 @@
 import { useStore } from '@nanostores/react'
 import type { CubeState, MoveToken, StickersByFace } from '@packages/cube-engine'
-import { applyMove, createSolvedState, toStickers } from '@packages/cube-engine'
+import {
+  applyMove,
+  applyMoves,
+  createSolvedState,
+  generateScramble,
+  toStickers
+} from '@packages/cube-engine'
 import { atom, computed } from 'nanostores'
 
 export const $cubeState = atom<CubeState>(createSolvedState())
@@ -15,6 +21,12 @@ export const applyMoveAction = (move: MoveToken) => {
 export const resetAction = () => {
   $cubeState.set(createSolvedState())
   $moveHistory.set([])
+}
+
+export const scrambleAction = () => {
+  const moves = generateScramble()
+  $cubeState.set(applyMoves(createSolvedState(), moves))
+  $moveHistory.set(moves)
 }
 
 export const useStickersByFace = (): StickersByFace => useStore($stickersByFace)

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -30,7 +30,6 @@ export const Home = () => (
           <li key={card.path}>
             <Link
               to={card.path}
-              aria-label={card.label}
               className={`card bg-base-200 focus-visible:ring-info border-l-4 no-underline shadow-sm transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:outline-none ${card.color}`}
             >
               <article className='card-body'>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -23,22 +23,25 @@ const MODE_CARDS = [
 ] as const
 
 export const Home = () => (
-  <div className='space-y-8'>
-    <ul className='grid grid-cols-1 gap-4 md:grid-cols-3'>
-      {MODE_CARDS.map(card => (
-        <li key={card.path}>
-          <Link
-            to={card.path}
-            className={`card bg-base-200 focus-visible:ring-info border-l-4 no-underline shadow-sm transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:outline-none ${card.color}`}
-          >
-            <article className='card-body'>
-              <h2 className='card-title'>{card.label}</h2>
-              <p>{card.description}</p>
-            </article>
-          </Link>
-        </li>
-      ))}
-    </ul>
+  <>
+    <nav aria-label='Modes' className='mb-8'>
+      <ul className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+        {MODE_CARDS.map(card => (
+          <li key={card.path}>
+            <Link
+              to={card.path}
+              aria-label={card.label}
+              className={`card bg-base-200 focus-visible:ring-info border-l-4 no-underline shadow-sm transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:outline-none ${card.color}`}
+            >
+              <article className='card-body'>
+                <h2 className='card-title'>{card.label}</h2>
+                <p>{card.description}</p>
+              </article>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
     <CubePlayground />
-  </div>
+  </>
 )

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -24,13 +24,13 @@
 
 ### Phase 3: Scramble Generator (cube-engine)
 
-- [ ] Create generateScramble use-case with injectable random source
-- [ ] Tests for scramble generation
-- [ ] Export from cube-engine barrel
+- [x] Create generateScramble use-case with injectable random source
+- [x] Tests for scramble generation
+- [x] Export from cube-engine barrel
 
 ### Phase 4: Wire Scramble and Final Verification
 
-- [ ] Add scrambleAction to store + tests
-- [ ] Wire Scramble button into CubePlayground
-- [ ] Update integration tests
-- [ ] Full verification (test, typecheck, lint, format)
+- [x] Add scrambleAction to store + tests
+- [x] Wire Scramble button into CubePlayground
+- [x] Update integration tests
+- [x] Full verification (test, typecheck, lint, format)

--- a/packages/cube-engine/src/application/use-cases/generateScramble.spec.ts
+++ b/packages/cube-engine/src/application/use-cases/generateScramble.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test'
+
+import { isFaceMove } from '~/domain/moves/tokens'
+import type { BaseFace } from '~/domain/moves/tokens'
+
+import { generateScramble } from './generateScramble'
+
+const OPPOSITE_FACES: Record<BaseFace, BaseFace> = {
+  U: 'D',
+  D: 'U',
+  F: 'B',
+  B: 'F',
+  L: 'R',
+  R: 'L'
+}
+
+const createSeededRandom = (seed: number) => {
+  let s = seed
+  return () => {
+    s = (s * 16807) % 2147483647
+    return s / 2147483647
+  }
+}
+
+describe('Use Case - generateScramble', () => {
+  it('should return exactly 20 moves by default', () => {
+    const moves = generateScramble()
+
+    expect(moves).toHaveLength(20)
+  })
+
+  it('should return custom length', () => {
+    const moves = generateScramble(10)
+
+    expect(moves).toHaveLength(10)
+  })
+
+  it('should only contain valid face moves', () => {
+    const moves = generateScramble(50, createSeededRandom(42))
+
+    moves.forEach(move => {
+      expect(isFaceMove(move)).toBe(true)
+    })
+  })
+
+  it('should not have consecutive moves on the same face', () => {
+    const moves = generateScramble(50, createSeededRandom(123))
+
+    for (let i = 1; i < moves.length; i++) {
+      expect(moves[i][0]).not.toBe(moves[i - 1][0])
+    }
+  })
+
+  it('should not have A-B-A pattern on opposite faces', () => {
+    const moves = generateScramble(50, createSeededRandom(456))
+
+    for (let i = 2; i < moves.length; i++) {
+      const face = moves[i][0] as BaseFace
+      const prevFace = moves[i - 1][0] as BaseFace
+      const prevPrevFace = moves[i - 2][0] as BaseFace
+
+      if (face === prevPrevFace) {
+        expect(OPPOSITE_FACES[face]).not.toBe(prevFace)
+      }
+    }
+  })
+
+  it('should be deterministic with seeded random', () => {
+    const a = generateScramble(20, createSeededRandom(999))
+    const b = generateScramble(20, createSeededRandom(999))
+
+    expect(a).toEqual(b)
+  })
+
+  it('should produce different results with different seeds', () => {
+    const a = generateScramble(20, createSeededRandom(1))
+    const b = generateScramble(20, createSeededRandom(2))
+
+    expect(a).not.toEqual(b)
+  })
+})

--- a/packages/cube-engine/src/application/use-cases/generateScramble.ts
+++ b/packages/cube-engine/src/application/use-cases/generateScramble.ts
@@ -1,0 +1,33 @@
+import type { BaseFace, MoveToken } from '~/domain/moves/tokens'
+import { FACE_MOVES } from '~/domain/moves/tokens'
+
+export type RandomSource = () => number
+
+const OPPOSITE_FACES: Record<BaseFace, BaseFace> = {
+  U: 'D',
+  D: 'U',
+  F: 'B',
+  B: 'F',
+  L: 'R',
+  R: 'L'
+}
+
+export const generateScramble = (length = 20, random: RandomSource = Math.random): MoveToken[] => {
+  const moves: MoveToken[] = []
+  let lastFace: BaseFace | null = null
+  let secondLastFace: BaseFace | null = null
+
+  while (moves.length < length) {
+    const move = FACE_MOVES[Math.floor(random() * FACE_MOVES.length)]
+    const face = move[0] as BaseFace
+
+    if (face === lastFace) continue
+    if (face === secondLastFace && OPPOSITE_FACES[face] === lastFace) continue
+
+    moves.push(move)
+    secondLastFace = lastFace
+    lastFace = face
+  }
+
+  return moves
+}

--- a/packages/cube-engine/src/index.ts
+++ b/packages/cube-engine/src/index.ts
@@ -42,6 +42,8 @@ export {
 // Application
 export { createSolvedState } from './application/use-cases/createSolvedState'
 export { applyMoves } from './application/use-cases/applyMoves'
+export { generateScramble } from './application/use-cases/generateScramble'
+export type { RandomSource } from './application/use-cases/generateScramble'
 
 // Infrastructure
 export { toStickers } from './infrastructure/render/toStickers'


### PR DESCRIPTION
## Summary

- **feat(cube-engine):** add `generateScramble` use-case with injectable random source, no-consecutive and no-A-B-A opposite-face filters, 7 deterministic tests
- **feat(web):** add `scrambleAction` to cube store, wire Scramble button into CubePlayground with integration tests
- **refactor(web):** improve semantic HTML — `ul/li` for sticker grids, `nav` landmark for mode cards, `aria-label` on links, `whitespace-nowrap` on move counter
- **docs:** update PROGRESS.md with completed Phase 3 and Phase 4

## Commits

1. `feat(cube-engine)`: add generateScramble use-case with injectable random source
2. `feat(web)`: wire scramble action into cube store and playground
3. `refactor(web)`: improve semantic HTML and accessibility
4. `docs(web)`: update PROGRESS.md with completed scramble phases

## Test plan

- [x] 91 cube-engine tests pass (including 7 generateScramble tests)
- [x] 86 web app tests pass (including scramble integration tests)
- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes
- [x] Manual: click Scramble, verify 20-move history and scrambled cube
- [x] Manual: Scramble then Reset returns to solved
- [x] Manual: verify move counter doesn't wrap on "20 moves"