### PR TITLE
feature: add solver input UI with cube state reconstruction

### DIFF
--- a/apps/web/src/features/cube/components/FaceGrid.tsx
+++ b/apps/web/src/features/cube/components/FaceGrid.tsx
@@ -1,15 +1,6 @@
 import type { ColorCode, FaceCode } from '@packages/cube-engine'
 
-import { colorNameByCode, stickerClassByColor } from '~/features/cube/lib/colors'
-
-const faceNameByCode: Record<FaceCode, string> = {
-  U: 'Up',
-  D: 'Down',
-  F: 'Front',
-  B: 'Back',
-  L: 'Left',
-  R: 'Right'
-}
+import { colorNameByCode, faceNameByCode, stickerClassByColor } from '~/features/cube/lib/colors'
 
 interface FaceGridProps {
   stickers: readonly ColorCode[]

--- a/apps/web/src/features/cube/lib/colors.ts
+++ b/apps/web/src/features/cube/lib/colors.ts
@@ -1,4 +1,13 @@
-import type { ColorCode } from '@packages/cube-engine'
+import type { ColorCode, FaceCode } from '@packages/cube-engine'
+
+export const faceNameByCode: Record<FaceCode, string> = {
+  U: 'Up',
+  D: 'Down',
+  F: 'Front',
+  B: 'Back',
+  L: 'Left',
+  R: 'Right'
+} as const
 
 export const stickerClassByColor: Record<ColorCode, string> = {
   Wt: 'bg-cube-white',

--- a/apps/web/src/features/solver/components/ColorPalette.spec.tsx
+++ b/apps/web/src/features/solver/components/ColorPalette.spec.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { ColorPalette } from '~/features/solver/components/ColorPalette'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ColorPalette', () => {
+  it('should render 6 color swatches', () => {
+    render(<ColorPalette selectedColor='Wt' onSelectColor={() => {}} />)
+
+    expect(screen.getAllByRole('button')).toHaveLength(6)
+  })
+
+  it('should have aria-labels for each color', () => {
+    render(<ColorPalette selectedColor='Wt' onSelectColor={() => {}} />)
+
+    expect(screen.getByLabelText('Select white')).toBeDefined()
+    expect(screen.getByLabelText('Select yellow')).toBeDefined()
+    expect(screen.getByLabelText('Select red')).toBeDefined()
+    expect(screen.getByLabelText('Select orange')).toBeDefined()
+    expect(screen.getByLabelText('Select blue')).toBeDefined()
+    expect(screen.getByLabelText('Select green')).toBeDefined()
+  })
+
+  it('should mark selected color as pressed', () => {
+    render(<ColorPalette selectedColor='Rd' onSelectColor={() => {}} />)
+
+    expect(screen.getByLabelText('Select red').getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByLabelText('Select white').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('should call onSelectColor when clicking a swatch', async () => {
+    const user = userEvent.setup()
+    const onSelectColor = mock(() => {})
+
+    render(<ColorPalette selectedColor='Wt' onSelectColor={onSelectColor} />)
+
+    await user.click(screen.getByLabelText('Select blue'))
+
+    expect(onSelectColor).toHaveBeenCalledTimes(1)
+    expect(onSelectColor).toHaveBeenCalledWith('Bl')
+  })
+})

--- a/apps/web/src/features/solver/components/ColorPalette.tsx
+++ b/apps/web/src/features/solver/components/ColorPalette.tsx
@@ -1,0 +1,28 @@
+import type { ColorCode } from '@packages/cube-engine'
+import { Color } from '@packages/cube-engine'
+
+import { colorNameByCode, stickerClassByColor } from '~/features/cube/lib/colors'
+
+const COLORS = Object.values(Color) as ColorCode[]
+
+interface ColorPaletteProps {
+  selectedColor: ColorCode
+  onSelectColor: (color: ColorCode) => void
+}
+
+export const ColorPalette = ({ selectedColor, onSelectColor }: ColorPaletteProps) => (
+  <nav className='flex gap-3' aria-label='Color palette'>
+    {COLORS.map(color => (
+      <button
+        key={color}
+        type='button'
+        className={`size-8 cursor-pointer rounded-full md:size-10 ${stickerClassByColor[color]} ${
+          color === selectedColor ? 'ring-base-content ring-2 ring-offset-2' : ''
+        }`}
+        aria-label={`Select ${colorNameByCode[color]}`}
+        aria-pressed={color === selectedColor}
+        onClick={() => onSelectColor(color)}
+      />
+    ))}
+  </nav>
+)

--- a/apps/web/src/features/solver/components/InteractiveCubeNet.spec.tsx
+++ b/apps/web/src/features/solver/components/InteractiveCubeNet.spec.tsx
@@ -13,9 +13,7 @@ afterEach(() => {
 
 describe('InteractiveCubeNet', () => {
   it('should render all 6 faces', () => {
-    render(
-      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={() => {}} />
-    )
+    render(<InteractiveCubeNet stickers={solvedStickers} onPaintSticker={() => {}} />)
 
     expect(screen.getByLabelText('Up face')).toBeDefined()
     expect(screen.getByLabelText('Down face')).toBeDefined()
@@ -26,9 +24,7 @@ describe('InteractiveCubeNet', () => {
   })
 
   it('should render 54 sticker buttons total', () => {
-    render(
-      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={() => {}} />
-    )
+    render(<InteractiveCubeNet stickers={solvedStickers} onPaintSticker={() => {}} />)
 
     expect(screen.getAllByRole('button')).toHaveLength(54)
   })
@@ -37,9 +33,7 @@ describe('InteractiveCubeNet', () => {
     const user = userEvent.setup()
     const onPaint = mock(() => {})
 
-    render(
-      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={onPaint} />
-    )
+    render(<InteractiveCubeNet stickers={solvedStickers} onPaintSticker={onPaint} />)
 
     const upFace = screen.getByLabelText('Up face')
     const buttons = upFace.querySelectorAll('button')

--- a/apps/web/src/features/solver/components/InteractiveCubeNet.spec.tsx
+++ b/apps/web/src/features/solver/components/InteractiveCubeNet.spec.tsx
@@ -1,0 +1,50 @@
+import { createSolvedState, toStickers } from '@packages/cube-engine'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { InteractiveCubeNet } from '~/features/solver/components/InteractiveCubeNet'
+
+const solvedStickers = toStickers(createSolvedState())
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('InteractiveCubeNet', () => {
+  it('should render all 6 faces', () => {
+    render(
+      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={() => {}} />
+    )
+
+    expect(screen.getByLabelText('Up face')).toBeDefined()
+    expect(screen.getByLabelText('Down face')).toBeDefined()
+    expect(screen.getByLabelText('Front face')).toBeDefined()
+    expect(screen.getByLabelText('Back face')).toBeDefined()
+    expect(screen.getByLabelText('Left face')).toBeDefined()
+    expect(screen.getByLabelText('Right face')).toBeDefined()
+  })
+
+  it('should render 54 sticker buttons total', () => {
+    render(
+      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={() => {}} />
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(54)
+  })
+
+  it('should call onPaintSticker with correct face and index', async () => {
+    const user = userEvent.setup()
+    const onPaint = mock(() => {})
+
+    render(
+      <InteractiveCubeNet stickers={solvedStickers} selectedColor='Rd' onPaintSticker={onPaint} />
+    )
+
+    const upFace = screen.getByLabelText('Up face')
+    const buttons = upFace.querySelectorAll('button')
+    await user.click(buttons[0])
+
+    expect(onPaint).toHaveBeenCalledWith('U', 0)
+  })
+})

--- a/apps/web/src/features/solver/components/InteractiveCubeNet.tsx
+++ b/apps/web/src/features/solver/components/InteractiveCubeNet.tsx
@@ -1,0 +1,62 @@
+import type { ColorCode, FaceCode, StickersByFace } from '@packages/cube-engine'
+
+import { InteractiveFaceGrid } from '~/features/solver/components/InteractiveFaceGrid'
+
+interface InteractiveCubeNetProps {
+  stickers: StickersByFace
+  selectedColor: ColorCode
+  onPaintSticker: (face: FaceCode, index: number) => void
+}
+
+export const InteractiveCubeNet = ({
+  stickers,
+  selectedColor,
+  onPaintSticker
+}: InteractiveCubeNetProps) => (
+  <section className='card bg-base-200 shadow-lg' aria-label='Interactive cube state'>
+    <div className='card-body grid grid-cols-4 grid-rows-3 place-items-center gap-4 p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8'>
+      <InteractiveFaceGrid
+        stickers={stickers.U}
+        face='U'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-2 row-start-1'
+      />
+      <InteractiveFaceGrid
+        stickers={stickers.L}
+        face='L'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-1 row-start-2'
+      />
+      <InteractiveFaceGrid
+        stickers={stickers.F}
+        face='F'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-2 row-start-2'
+      />
+      <InteractiveFaceGrid
+        stickers={stickers.R}
+        face='R'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-3 row-start-2'
+      />
+      <InteractiveFaceGrid
+        stickers={stickers.B}
+        face='B'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-4 row-start-2'
+      />
+      <InteractiveFaceGrid
+        stickers={stickers.D}
+        face='D'
+        selectedColor={selectedColor}
+        onPaintSticker={onPaintSticker}
+        className='col-start-2 row-start-3'
+      />
+    </div>
+  </section>
+)

--- a/apps/web/src/features/solver/components/InteractiveCubeNet.tsx
+++ b/apps/web/src/features/solver/components/InteractiveCubeNet.tsx
@@ -1,59 +1,48 @@
-import type { ColorCode, FaceCode, StickersByFace } from '@packages/cube-engine'
+import type { FaceCode, StickersByFace } from '@packages/cube-engine'
 
 import { InteractiveFaceGrid } from '~/features/solver/components/InteractiveFaceGrid'
 
 interface InteractiveCubeNetProps {
   stickers: StickersByFace
-  selectedColor: ColorCode
   onPaintSticker: (face: FaceCode, index: number) => void
 }
 
-export const InteractiveCubeNet = ({
-  stickers,
-  selectedColor,
-  onPaintSticker
-}: InteractiveCubeNetProps) => (
+export const InteractiveCubeNet = ({ stickers, onPaintSticker }: InteractiveCubeNetProps) => (
   <section className='card bg-base-200 shadow-lg' aria-label='Interactive cube state'>
     <div className='card-body grid grid-cols-4 grid-rows-3 place-items-center gap-4 p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8'>
       <InteractiveFaceGrid
         stickers={stickers.U}
         face='U'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-2 row-start-1'
       />
       <InteractiveFaceGrid
         stickers={stickers.L}
         face='L'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-1 row-start-2'
       />
       <InteractiveFaceGrid
         stickers={stickers.F}
         face='F'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-2 row-start-2'
       />
       <InteractiveFaceGrid
         stickers={stickers.R}
         face='R'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-3 row-start-2'
       />
       <InteractiveFaceGrid
         stickers={stickers.B}
         face='B'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-4 row-start-2'
       />
       <InteractiveFaceGrid
         stickers={stickers.D}
         face='D'
-        selectedColor={selectedColor}
         onPaintSticker={onPaintSticker}
         className='col-start-2 row-start-3'
       />

--- a/apps/web/src/features/solver/components/InteractiveFaceGrid.spec.tsx
+++ b/apps/web/src/features/solver/components/InteractiveFaceGrid.spec.tsx
@@ -1,0 +1,107 @@
+import type { ColorCode } from '@packages/cube-engine'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+import { InteractiveFaceGrid } from '~/features/solver/components/InteractiveFaceGrid'
+
+const whiteFace: readonly ColorCode[] = ['Wt', 'Wt', 'Wt', 'Wt', 'Wt', 'Wt', 'Wt', 'Wt', 'Wt']
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('InteractiveFaceGrid', () => {
+  it('should render 9 sticker buttons', () => {
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='U'
+        selectedColor='Rd'
+        onPaintSticker={() => {}}
+      />
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(9)
+  })
+
+  it('should render face label', () => {
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='U'
+        selectedColor='Rd'
+        onPaintSticker={() => {}}
+      />
+    )
+
+    expect(screen.getByLabelText('Up face')).toBeDefined()
+  })
+
+  it('should call onPaintSticker when clicking a non-center sticker', async () => {
+    const user = userEvent.setup()
+    const onPaint = mock(() => {})
+
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='F'
+        selectedColor='Rd'
+        onPaintSticker={onPaint}
+      />
+    )
+
+    const buttons = screen.getAllByRole('button')
+    await user.click(buttons[0])
+
+    expect(onPaint).toHaveBeenCalledTimes(1)
+    expect(onPaint).toHaveBeenCalledWith('F', 0)
+  })
+
+  it('should not call onPaintSticker when clicking center sticker', async () => {
+    const user = userEvent.setup()
+    const onPaint = mock(() => {})
+
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='U'
+        selectedColor='Rd'
+        onPaintSticker={onPaint}
+      />
+    )
+
+    const buttons = screen.getAllByRole('button')
+    await user.click(buttons[4])
+
+    expect(onPaint).toHaveBeenCalledTimes(0)
+  })
+
+  it('should disable center sticker button', () => {
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='U'
+        selectedColor='Rd'
+        onPaintSticker={() => {}}
+      />
+    )
+
+    const buttons = screen.getAllByRole('button')
+    expect((buttons[4] as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('should have aria-labels with color names', () => {
+    render(
+      <InteractiveFaceGrid
+        stickers={whiteFace}
+        face='U'
+        selectedColor='Rd'
+        onPaintSticker={() => {}}
+      />
+    )
+
+    expect(screen.getByLabelText('Up sticker 0: white')).toBeDefined()
+    expect(screen.getByLabelText('Up sticker 4: white')).toBeDefined()
+  })
+})

--- a/apps/web/src/features/solver/components/InteractiveFaceGrid.spec.tsx
+++ b/apps/web/src/features/solver/components/InteractiveFaceGrid.spec.tsx
@@ -13,27 +13,13 @@ afterEach(() => {
 
 describe('InteractiveFaceGrid', () => {
   it('should render 9 sticker buttons', () => {
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='U'
-        selectedColor='Rd'
-        onPaintSticker={() => {}}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='U' onPaintSticker={() => {}} />)
 
     expect(screen.getAllByRole('button')).toHaveLength(9)
   })
 
   it('should render face label', () => {
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='U'
-        selectedColor='Rd'
-        onPaintSticker={() => {}}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='U' onPaintSticker={() => {}} />)
 
     expect(screen.getByLabelText('Up face')).toBeDefined()
   })
@@ -42,14 +28,7 @@ describe('InteractiveFaceGrid', () => {
     const user = userEvent.setup()
     const onPaint = mock(() => {})
 
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='F'
-        selectedColor='Rd'
-        onPaintSticker={onPaint}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='F' onPaintSticker={onPaint} />)
 
     const buttons = screen.getAllByRole('button')
     await user.click(buttons[0])
@@ -62,14 +41,7 @@ describe('InteractiveFaceGrid', () => {
     const user = userEvent.setup()
     const onPaint = mock(() => {})
 
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='U'
-        selectedColor='Rd'
-        onPaintSticker={onPaint}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='U' onPaintSticker={onPaint} />)
 
     const buttons = screen.getAllByRole('button')
     await user.click(buttons[4])
@@ -78,28 +50,14 @@ describe('InteractiveFaceGrid', () => {
   })
 
   it('should disable center sticker button', () => {
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='U'
-        selectedColor='Rd'
-        onPaintSticker={() => {}}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='U' onPaintSticker={() => {}} />)
 
     const buttons = screen.getAllByRole('button')
     expect((buttons[4] as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('should have aria-labels with color names', () => {
-    render(
-      <InteractiveFaceGrid
-        stickers={whiteFace}
-        face='U'
-        selectedColor='Rd'
-        onPaintSticker={() => {}}
-      />
-    )
+    render(<InteractiveFaceGrid stickers={whiteFace} face='U' onPaintSticker={() => {}} />)
 
     expect(screen.getByLabelText('Up sticker 0: white')).toBeDefined()
     expect(screen.getByLabelText('Up sticker 4: white')).toBeDefined()

--- a/apps/web/src/features/solver/components/InteractiveFaceGrid.tsx
+++ b/apps/web/src/features/solver/components/InteractiveFaceGrid.tsx
@@ -1,0 +1,58 @@
+import type { ColorCode, FaceCode } from '@packages/cube-engine'
+
+import { colorNameByCode, faceNameByCode, stickerClassByColor } from '~/features/cube/lib/colors'
+
+interface InteractiveFaceGridProps {
+  stickers: readonly ColorCode[]
+  face: FaceCode
+  selectedColor: ColorCode
+  onPaintSticker: (face: FaceCode, index: number) => void
+  className?: string
+}
+
+export const InteractiveFaceGrid = ({
+  stickers,
+  face,
+  selectedColor,
+  onPaintSticker,
+  className = ''
+}: InteractiveFaceGridProps) => {
+  if (stickers.length !== 9) {
+    throw new Error(`InteractiveFaceGrid expects 9 stickers, got ${stickers.length}`)
+  }
+
+  return (
+    <figure
+      className={`inline-flex flex-col gap-2 ${className}`}
+      aria-label={`${faceNameByCode[face]} face`}
+    >
+      <figcaption className='text-base-content/70 text-center text-xs tracking-widest'>
+        {face}
+      </figcaption>
+
+      <ul className='bg-base-300 ring-base-content/20 grid size-20 grid-cols-3 gap-1 rounded-sm p-1 ring-1 md:size-28 lg:size-36'>
+        {stickers.slice(0, 9).map((color, index) => {
+          const isCenter = index === 4
+
+          return (
+            <li key={index}>
+              <button
+                type='button'
+                className={`aspect-square w-full rounded-xs ring-1 transition-shadow ${stickerClassByColor[color]} ${
+                  isCenter
+                    ? 'ring-base-content/10 cursor-default'
+                    : 'ring-base-content/10 hover:shadow-primary/20 cursor-pointer hover:shadow-md'
+                }`}
+                aria-label={`${faceNameByCode[face]} sticker ${index}: ${colorNameByCode[color]}`}
+                disabled={isCenter}
+                onClick={() => {
+                  if (!isCenter) onPaintSticker(face, index)
+                }}
+              />
+            </li>
+          )
+        })}
+      </ul>
+    </figure>
+  )
+}

--- a/apps/web/src/features/solver/components/InteractiveFaceGrid.tsx
+++ b/apps/web/src/features/solver/components/InteractiveFaceGrid.tsx
@@ -5,7 +5,6 @@ import { colorNameByCode, faceNameByCode, stickerClassByColor } from '~/features
 interface InteractiveFaceGridProps {
   stickers: readonly ColorCode[]
   face: FaceCode
-  selectedColor: ColorCode
   onPaintSticker: (face: FaceCode, index: number) => void
   className?: string
 }
@@ -13,7 +12,6 @@ interface InteractiveFaceGridProps {
 export const InteractiveFaceGrid = ({
   stickers,
   face,
-  selectedColor,
   onPaintSticker,
   className = ''
 }: InteractiveFaceGridProps) => {

--- a/apps/web/src/features/solver/components/index.ts
+++ b/apps/web/src/features/solver/components/index.ts
@@ -1,0 +1,3 @@
+export { ColorPalette } from './ColorPalette'
+export { InteractiveCubeNet } from './InteractiveCubeNet'
+export { InteractiveFaceGrid } from './InteractiveFaceGrid'

--- a/apps/web/src/features/solver/index.ts
+++ b/apps/web/src/features/solver/index.ts
@@ -1,0 +1,12 @@
+export { ColorPalette, InteractiveCubeNet, InteractiveFaceGrid } from './components'
+export {
+  paintSticker,
+  resetInput,
+  scrambleInput,
+  selectColor,
+  useInputStickers,
+  useSelectedColor,
+  useSolverView,
+  useValidationResult
+} from './stores'
+export type { SolverView } from './stores'

--- a/apps/web/src/features/solver/stores/index.ts
+++ b/apps/web/src/features/solver/stores/index.ts
@@ -1,0 +1,15 @@
+export {
+  $inputStickers,
+  $selectedColor,
+  $solverView,
+  $validationResult,
+  paintSticker,
+  resetInput,
+  scrambleInput,
+  selectColor,
+  useInputStickers,
+  useSelectedColor,
+  useSolverView,
+  useValidationResult
+} from './solverStore'
+export type { SolverView } from './solverStore'

--- a/apps/web/src/features/solver/stores/solverStore.spec.ts
+++ b/apps/web/src/features/solver/stores/solverStore.spec.ts
@@ -1,0 +1,74 @@
+import { Color, createSolvedState, toStickers } from '@packages/cube-engine'
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+import {
+  $inputStickers,
+  $selectedColor,
+  $validationResult,
+  paintSticker,
+  resetInput,
+  scrambleInput,
+  selectColor
+} from '~/features/solver/stores'
+
+beforeEach(() => {
+  resetInput()
+  selectColor('Wt')
+})
+
+describe('solverStore', () => {
+  it('should initialize stickers to solved state', () => {
+    const expected = toStickers(createSolvedState())
+    expect($inputStickers.get()).toEqual(expected)
+  })
+
+  it('should initialize selected color to white', () => {
+    expect($selectedColor.get()).toBe('Wt')
+  })
+
+  it('should validate solved stickers as valid', () => {
+    const result = $validationResult.get()
+    expect(result.ok).toBe(true)
+  })
+
+  it('should paint a sticker at given face and index', () => {
+    paintSticker('U', 0, Color.Red)
+    expect($inputStickers.get()['U'][0]).toBe('Rd')
+  })
+
+  it('should not paint center stickers (index 4)', () => {
+    const before = $inputStickers.get()['U'][4]
+    paintSticker('U', 4, Color.Red)
+    expect($inputStickers.get()['U'][4]).toBe(before)
+  })
+
+  it('should update selected color', () => {
+    selectColor('Rd')
+    expect($selectedColor.get()).toBe('Rd')
+  })
+
+  it('should reset stickers to solved state', () => {
+    paintSticker('U', 0, Color.Red)
+    resetInput()
+    const expected = toStickers(createSolvedState())
+    expect($inputStickers.get()).toEqual(expected)
+  })
+
+  it('should scramble input stickers', () => {
+    scrambleInput()
+    const solved = toStickers(createSolvedState())
+    expect($inputStickers.get()).not.toEqual(solved)
+  })
+
+  it('should invalidate after painting wrong color count', () => {
+    paintSticker('U', 0, Color.Red)
+    const result = $validationResult.get()
+    expect(result.ok).toBe(false)
+  })
+
+  it('should revalidate after scramble', () => {
+    scrambleInput()
+    const result = $validationResult.get()
+    expect(result.ok).toBe(true)
+  })
+})

--- a/apps/web/src/features/solver/stores/solverStore.ts
+++ b/apps/web/src/features/solver/stores/solverStore.ts
@@ -1,0 +1,48 @@
+import { useStore } from '@nanostores/react'
+import type { ColorCode, FaceCode, ReconstructResult, StickersByFace } from '@packages/cube-engine'
+import {
+  applyMoves,
+  createSolvedState,
+  generateScramble,
+  reconstructState,
+  toStickers
+} from '@packages/cube-engine'
+import { atom, computed } from 'nanostores'
+
+export type SolverView = 'input' | 'solution'
+
+export const $inputStickers = atom<StickersByFace>(toStickers(createSolvedState()))
+export const $selectedColor = atom<ColorCode>('Wt')
+export const $solverView = atom<SolverView>('input')
+
+export const $validationResult = computed($inputStickers, (stickers): ReconstructResult => {
+  return reconstructState(stickers)
+})
+
+export const paintSticker = (face: FaceCode, index: number, color: ColorCode) => {
+  if (index === 4) return
+
+  const current = $inputStickers.get()
+  const faceStickers = [...current[face]]
+  faceStickers[index] = color
+  $inputStickers.set({ ...current, [face]: faceStickers })
+}
+
+export const selectColor = (color: ColorCode) => {
+  $selectedColor.set(color)
+}
+
+export const resetInput = () => {
+  $inputStickers.set(toStickers(createSolvedState()))
+}
+
+export const scrambleInput = () => {
+  const moves = generateScramble()
+  const state = applyMoves(createSolvedState(), moves)
+  $inputStickers.set(toStickers(state))
+}
+
+export const useInputStickers = (): StickersByFace => useStore($inputStickers)
+export const useSelectedColor = (): ColorCode => useStore($selectedColor)
+export const useValidationResult = (): ReconstructResult => useStore($validationResult)
+export const useSolverView = (): SolverView => useStore($solverView)

--- a/apps/web/src/pages/Solver.spec.tsx
+++ b/apps/web/src/pages/Solver.spec.tsx
@@ -1,7 +1,13 @@
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'bun:test'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
+import { resetInput } from '~/features/solver/stores'
 import { Solver } from '~/pages/Solver'
+
+beforeEach(() => {
+  resetInput()
+})
 
 afterEach(() => {
   cleanup()
@@ -10,11 +16,82 @@ afterEach(() => {
 describe('Solver', () => {
   it('should render the title', () => {
     render(<Solver />)
+
     expect(screen.getByText('Solver')).toBeDefined()
   })
 
-  it('should render the coming soon message', () => {
+  it('should render the color palette', () => {
     render(<Solver />)
-    expect(screen.getByText('Coming soon')).toBeDefined()
+
+    expect(screen.getByLabelText('Color palette')).toBeDefined()
+  })
+
+  it('should render the interactive cube net', () => {
+    render(<Solver />)
+
+    expect(screen.getByLabelText('Interactive cube state')).toBeDefined()
+  })
+
+  it('should render action buttons', () => {
+    render(<Solver />)
+
+    expect(screen.getByText('Reset')).toBeDefined()
+    expect(screen.getByText('Scramble')).toBeDefined()
+    expect(screen.getByText('Solve')).toBeDefined()
+  })
+
+  it('should disable Solve button for solved state', () => {
+    render(<Solver />)
+
+    const solveBtn = screen.getByText('Solve')
+    expect((solveBtn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('should show already solved message for initial state', () => {
+    render(<Solver />)
+
+    expect(screen.getByText('Cube is already solved')).toBeDefined()
+  })
+
+  it('should show validation error after painting invalid stickers', async () => {
+    const user = userEvent.setup()
+    render(<Solver />)
+
+    await user.click(screen.getByLabelText('Select red'))
+
+    const upFace = screen.getByLabelText('Up face')
+    const buttons = upFace.querySelectorAll('button')
+    await user.click(buttons[0])
+
+    expect(screen.getByText(/Expected 9 white stickers/)).toBeDefined()
+  })
+
+  it('should enable Solve button after scramble', async () => {
+    const user = userEvent.setup()
+    render(<Solver />)
+
+    await user.click(screen.getByText('Scramble'))
+
+    const solveBtn = screen.getByText('Solve')
+    expect((solveBtn as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('should show valid state message after scramble', async () => {
+    const user = userEvent.setup()
+    render(<Solver />)
+
+    await user.click(screen.getByText('Scramble'))
+
+    expect(screen.getByText('Valid cube state')).toBeDefined()
+  })
+
+  it('should reset to solved state when clicking Reset', async () => {
+    const user = userEvent.setup()
+    render(<Solver />)
+
+    await user.click(screen.getByText('Scramble'))
+    await user.click(screen.getByText('Reset'))
+
+    expect(screen.getByText('Cube is already solved')).toBeDefined()
   })
 })

--- a/apps/web/src/pages/Solver.tsx
+++ b/apps/web/src/pages/Solver.tsx
@@ -33,7 +33,6 @@ export const Solver = () => {
 
       <InteractiveCubeNet
         stickers={stickers}
-        selectedColor={selectedColor}
         onPaintSticker={(face, index) => paintSticker(face, index, selectedColor)}
       />
 

--- a/apps/web/src/pages/Solver.tsx
+++ b/apps/web/src/pages/Solver.tsx
@@ -1,6 +1,73 @@
-export const Solver = () => (
-  <div>
-    <h1 className='text-cube-blue-text text-2xl font-bold'>Solver</h1>
-    <p className='text-neutral-content mt-2'>Coming soon</p>
-  </div>
-)
+import { ColorPalette } from '~/features/solver/components/ColorPalette'
+import { InteractiveCubeNet } from '~/features/solver/components/InteractiveCubeNet'
+import {
+  paintSticker,
+  resetInput,
+  scrambleInput,
+  selectColor,
+  useInputStickers,
+  useSelectedColor,
+  useValidationResult
+} from '~/features/solver/stores'
+
+export const Solver = () => {
+  const stickers = useInputStickers()
+  const selectedColor = useSelectedColor()
+  const validation = useValidationResult()
+
+  const isSolved =
+    validation.ok && Object.values(stickers).every(face => face.every(c => c === face[4]))
+
+  const canSolve = validation.ok && !isSolved
+
+  return (
+    <section className='flex flex-col gap-6' aria-label='Solver'>
+      <header>
+        <h1 className='text-cube-blue-text text-2xl font-bold'>Solver</h1>
+        <p className='text-base-content/60 mt-1 text-sm'>
+          Paint your cube state, then solve it step by step
+        </p>
+      </header>
+
+      <ColorPalette selectedColor={selectedColor} onSelectColor={selectColor} />
+
+      <InteractiveCubeNet
+        stickers={stickers}
+        selectedColor={selectedColor}
+        onPaintSticker={(face, index) => paintSticker(face, index, selectedColor)}
+      />
+
+      <div className='min-h-8' aria-live='polite'>
+        {validation.ok ? (
+          isSolved ? (
+            <p className='text-base-content/60 text-sm'>Cube is already solved</p>
+          ) : (
+            <p className='text-success text-sm'>Valid cube state</p>
+          )
+        ) : (
+          <ul className='text-error list-disc pl-5 text-sm'>
+            {validation.errors.map((error, i) => (
+              <li key={i}>{error}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <nav className='flex items-center gap-4' aria-label='Solver actions'>
+        <button type='button' className='btn btn-soft cursor-pointer' onClick={resetInput}>
+          Reset
+        </button>
+        <button type='button' className='btn btn-soft cursor-pointer' onClick={scrambleInput}>
+          Scramble
+        </button>
+        <button
+          type='button'
+          className='btn btn-primary ml-auto cursor-pointer'
+          disabled={!canSolve}
+        >
+          Solve
+        </button>
+      </nav>
+    </section>
+  )
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -4,17 +4,17 @@
 
 ### Phase 1: Interactive CubeNet Input + Engine Validation
 
-- [ ] Create state reconstruction use case (stickers → CubeState + validation)
-- [ ] Tests for reconstruction + validation
-- [ ] Create move inverse utility (invertMove, invertMoves)
-- [ ] Tests for move inverse
-- [ ] Create solver store (input part: stickers, selected color, validation)
-- [ ] Create ColorPalette component
-- [ ] Create InteractiveFaceGrid component (clickable stickers)
-- [ ] Create InteractiveCubeNet component
-- [ ] Tests for input components
-- [ ] Replace Solver page placeholder with input assembly
-- [ ] Update Solver page tests
+- [x] Create state reconstruction use case (stickers → CubeState + validation)
+- [x] Tests for reconstruction + validation
+- [x] Create move inverse utility (invertMove, invertMoves)
+- [x] Tests for move inverse
+- [x] Create solver store (input part: stickers, selected color, validation)
+- [x] Create ColorPalette component
+- [x] Create InteractiveFaceGrid component (clickable stickers)
+- [x] Create InteractiveCubeNet component
+- [x] Tests for input components
+- [x] Replace Solver page placeholder with input assembly
+- [x] Update Solver page tests
 
 ### Phase 2: White Cross Solver
 

--- a/packages/cube-engine/src/application/use-cases/invertMoves.spec.ts
+++ b/packages/cube-engine/src/application/use-cases/invertMoves.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { MoveToken } from '~/domain'
+
+import { applyMoves } from './applyMoves'
+import { createSolvedState } from './createSolvedState'
+import { invertMove, invertMoves } from './invertMoves'
+
+describe('Use Case - invertMove', () => {
+  it('should invert quarter turns', () => {
+    expect(invertMove('R')).toBe("R'")
+    expect(invertMove("U'")).toBe('U')
+    expect(invertMove('F')).toBe("F'")
+    expect(invertMove("L'")).toBe('L')
+  })
+
+  it('should keep double turns unchanged', () => {
+    expect(invertMove('F2')).toBe('F2')
+    expect(invertMove('R2')).toBe('R2')
+    expect(invertMove('U2')).toBe('U2')
+  })
+})
+
+describe('Use Case - invertMoves', () => {
+  it('should reverse and invert a sequence', () => {
+    const moves: MoveToken[] = ['R', 'U', "F'"]
+    expect(invertMoves(moves)).toEqual(['F', "U'", "R'"])
+  })
+
+  it('should return empty array for empty input', () => {
+    expect(invertMoves([])).toEqual([])
+  })
+
+  it('should produce identity when applied after original moves', () => {
+    const moves: MoveToken[] = ['R', "U'", 'F2', 'D', "L'", 'B']
+    const solved = createSolvedState()
+    const scrambled = applyMoves(solved, moves)
+    const result = applyMoves(scrambled, invertMoves(moves))
+
+    expect(result).toEqual(solved)
+  })
+})

--- a/packages/cube-engine/src/application/use-cases/invertMoves.ts
+++ b/packages/cube-engine/src/application/use-cases/invertMoves.ts
@@ -1,0 +1,27 @@
+import type { MoveToken } from '~/domain'
+
+const INVERSE_MAP: Record<MoveToken, MoveToken> = {
+  U: "U'",
+  "U'": 'U',
+  U2: 'U2',
+  D: "D'",
+  "D'": 'D',
+  D2: 'D2',
+  R: "R'",
+  "R'": 'R',
+  R2: 'R2',
+  L: "L'",
+  "L'": 'L',
+  L2: 'L2',
+  F: "F'",
+  "F'": 'F',
+  F2: 'F2',
+  B: "B'",
+  "B'": 'B',
+  B2: 'B2'
+}
+
+export const invertMove = (move: MoveToken): MoveToken => INVERSE_MAP[move]
+
+export const invertMoves = (moves: readonly MoveToken[]): MoveToken[] =>
+  [...moves].reverse().map(invertMove)

--- a/packages/cube-engine/src/application/use-cases/reconstructState.spec.ts
+++ b/packages/cube-engine/src/application/use-cases/reconstructState.spec.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'bun:test'
+
+import type { ColorCode, FaceCode, MoveToken } from '~/domain'
+import { Color } from '~/domain/constants'
+import type { StickersByFace } from '~/infrastructure/render/toStickers'
+import { toStickers } from '~/infrastructure/render/toStickers'
+
+import { applyMoves } from './applyMoves'
+import { createSolvedState } from './createSolvedState'
+import { reconstructState } from './reconstructState'
+
+const solvedStickers = (): StickersByFace => toStickers(createSolvedState())
+
+const setStickerAt = (
+  stickers: StickersByFace,
+  face: FaceCode,
+  index: number,
+  color: ColorCode
+): StickersByFace => {
+  const copy = { ...stickers }
+  copy[face] = [...copy[face]]
+  copy[face][index] = color
+  return copy
+}
+
+describe('Use Case - reconstructState', () => {
+  it('should reconstruct solved stickers to solved state', () => {
+    const result = reconstructState(solvedStickers())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const solvedState = createSolvedState()
+    expect(result.state).toEqual(solvedState)
+  })
+
+  it('should reconstruct a scrambled state correctly', () => {
+    const moves: MoveToken[] = ['R', 'U', "F'", 'D2', 'L']
+    const originalState = applyMoves(createSolvedState(), moves)
+    const stickers = toStickers(originalState)
+
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.state).toEqual(originalState)
+  })
+
+  it('should reconstruct after a long scramble', () => {
+    const moves: MoveToken[] = [
+      'R',
+      'U',
+      "F'",
+      'D2',
+      'L',
+      "B'",
+      'R2',
+      'U',
+      'D',
+      "L'",
+      'F',
+      'B',
+      "R'",
+      'U2',
+      'D',
+      'F2',
+      "B'",
+      'L',
+      "R'",
+      'U'
+    ]
+    const originalState = applyMoves(createSolvedState(), moves)
+    const stickers = toStickers(originalState)
+
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.state).toEqual(originalState)
+  })
+
+  it('should return error for wrong color count', () => {
+    const stickers = setStickerAt(solvedStickers(), 'U', 0, Color.Red)
+
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some(e => e.includes('white'))).toBe(true)
+    expect(result.errors.some(e => e.includes('red'))).toBe(true)
+  })
+
+  it('should return error for invalid corner color combination', () => {
+    // Swap U:8 (UFR on U=Wt) with F:2 (UFR on F=Gn) to create a flipped corner
+    // that violates orientation sum
+    const fresh = solvedStickers()
+    const ufrOnU = fresh['U'][8]
+    const ufrOnF = fresh['F'][2]
+    const swapped = setStickerAt(setStickerAt(fresh, 'U', 8, ufrOnF), 'F', 2, ufrOnU)
+
+    const result = reconstructState(swapped)
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('should return error for duplicate piece', () => {
+    // Make UB edge look like UF edge (Wt-Gn duplicate), compensate counts elsewhere
+    let stickers = solvedStickers()
+    stickers = setStickerAt(stickers, 'B', 1, Color.Green)
+    stickers = setStickerAt(stickers, 'F', 3, Color.Blue)
+
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some(e => e.includes('Duplicate'))).toBe(true)
+  })
+
+  it('should return error for impossible corner orientation sum', () => {
+    const state = createSolvedState()
+    const twistedState = {
+      ...state,
+      corners: {
+        ...state.corners,
+        UFR: { ...state.corners.UFR, orientation: 1 as const }
+      }
+    }
+    const stickers = toStickers(twistedState)
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some(e => e.includes('corner orientations'))).toBe(true)
+  })
+
+  it('should return error for impossible edge orientation sum', () => {
+    const state = createSolvedState()
+    const flippedState = {
+      ...state,
+      edges: {
+        ...state.edges,
+        UF: { ...state.edges.UF, orientation: 1 as const }
+      }
+    }
+    const stickers = toStickers(flippedState)
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some(e => e.includes('edge orientations'))).toBe(true)
+  })
+
+  it('should return error for parity mismatch', () => {
+    const state = createSolvedState()
+    const ufPiece = state.edges.UF
+    const urPiece = state.edges.UR
+    const swappedState = {
+      ...state,
+      edges: {
+        ...state.edges,
+        UF: { ...urPiece, position: 'UF' as const },
+        UR: { ...ufPiece, position: 'UR' as const }
+      }
+    }
+    const stickers = toStickers(swappedState)
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.some(e => e.includes('parity mismatch'))).toBe(true)
+  })
+
+  it('should return multiple errors at once', () => {
+    const state = createSolvedState()
+    const brokenState = {
+      ...state,
+      corners: {
+        ...state.corners,
+        UFR: { ...state.corners.UFR, orientation: 1 as const }
+      },
+      edges: {
+        ...state.edges,
+        UF: { ...state.edges.UF, orientation: 1 as const }
+      }
+    }
+    const stickers = toStickers(brokenState)
+    const result = reconstructState(stickers)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.errors.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should be the inverse of toStickers for valid states', () => {
+    const scrambles: MoveToken[][] = [
+      ['R', 'U'],
+      ["R'", 'U2', 'F'],
+      ['R', 'U', "F'", 'D', 'L', 'B'],
+      ['R2', "U'", 'F2', "D'", 'L2', "B'", 'R', 'U', 'F', 'D']
+    ]
+
+    for (const moves of scrambles) {
+      const state = applyMoves(createSolvedState(), moves)
+      const stickers = toStickers(state)
+      const result = reconstructState(stickers)
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) continue
+      expect(result.state).toEqual(state)
+    }
+  })
+})

--- a/packages/cube-engine/src/application/use-cases/reconstructState.ts
+++ b/packages/cube-engine/src/application/use-cases/reconstructState.ts
@@ -132,9 +132,17 @@ const computeParity = <T extends string>(
 
 export const reconstructState = (stickers: StickersByFace): ReconstructResult => {
   const errors: string[] = []
+  const faces = ['U', 'D', 'F', 'B', 'L', 'R'] as const
+
+  // 0. Validate input shape (all 6 faces present with 9 stickers each)
+  for (const face of faces) {
+    if (!Array.isArray(stickers[face]) || stickers[face].length !== 9) {
+      return { ok: false, errors: [`Missing or invalid sticker array for face ${face}`] }
+    }
+  }
 
   // 1. Validate color counts (exactly 9 of each)
-  const allStickers = (['U', 'D', 'F', 'B', 'L', 'R'] as const).flatMap(f => stickers[f])
+  const allStickers = faces.flatMap(f => stickers[f])
   const colorCounts = new Map<ColorCode, number>()
   for (const color of allStickers) {
     colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1)
@@ -149,7 +157,6 @@ export const reconstructState = (stickers: StickersByFace): ReconstructResult =>
   if (errors.length > 0) return { ok: false, errors }
 
   // 2. Validate centers (each color exactly once)
-  const faces = ['U', 'D', 'F', 'B', 'L', 'R'] as const
   const centers = {} as Record<FaceCode, ColorCode>
   const centerColors = new Set<ColorCode>()
   for (const face of faces) {

--- a/packages/cube-engine/src/application/use-cases/reconstructState.ts
+++ b/packages/cube-engine/src/application/use-cases/reconstructState.ts
@@ -1,0 +1,281 @@
+import type {
+  ColorCode,
+  CornerOrientation,
+  CornerPositionId,
+  CubeState,
+  EdgeOrientation,
+  EdgePositionId,
+  FaceCode,
+  StickerIndex
+} from '~/domain'
+import { Color, CornerPosition, EdgePosition } from '~/domain/constants'
+import { cornerColorIndex, stickerMapping } from '~/domain/geometry'
+import { makeCornerPiece, makeEdgePiece } from '~/domain/pieces'
+import type { StickersByFace } from '~/infrastructure/render/toStickers'
+
+export type ReconstructResult = { ok: true; state: CubeState } | { ok: false; errors: string[] }
+
+// --- Color name mapping for error messages ---
+
+const colorName: Record<ColorCode, string> = {
+  Wt: 'white',
+  Yl: 'yellow',
+  Rd: 'red',
+  Og: 'orange',
+  Bl: 'blue',
+  Gn: 'green'
+}
+
+// --- Piece definitions (matching createSolvedState) ---
+
+const CORNER_DEFS: readonly {
+  id: CornerPositionId
+  colors: [ColorCode, ColorCode, ColorCode]
+}[] = [
+  { id: 'UFR', colors: [Color.White, Color.Green, Color.Red] },
+  { id: 'URB', colors: [Color.White, Color.Red, Color.Blue] },
+  { id: 'UBL', colors: [Color.White, Color.Blue, Color.Orange] },
+  { id: 'ULF', colors: [Color.White, Color.Orange, Color.Green] },
+  { id: 'DFR', colors: [Color.Yellow, Color.Green, Color.Red] },
+  { id: 'DRB', colors: [Color.Yellow, Color.Red, Color.Blue] },
+  { id: 'DBL', colors: [Color.Yellow, Color.Blue, Color.Orange] },
+  { id: 'DLF', colors: [Color.Yellow, Color.Orange, Color.Green] }
+]
+
+const EDGE_DEFS: readonly {
+  id: EdgePositionId
+  colors: [ColorCode, ColorCode]
+}[] = [
+  { id: 'UF', colors: [Color.White, Color.Green] },
+  { id: 'UR', colors: [Color.White, Color.Red] },
+  { id: 'UB', colors: [Color.White, Color.Blue] },
+  { id: 'UL', colors: [Color.White, Color.Orange] },
+  { id: 'DF', colors: [Color.Yellow, Color.Green] },
+  { id: 'DR', colors: [Color.Yellow, Color.Red] },
+  { id: 'DB', colors: [Color.Yellow, Color.Blue] },
+  { id: 'DL', colors: [Color.Yellow, Color.Orange] },
+  { id: 'FR', colors: [Color.Green, Color.Red] },
+  { id: 'FL', colors: [Color.Green, Color.Orange] },
+  { id: 'BR', colors: [Color.Blue, Color.Red] },
+  { id: 'BL', colors: [Color.Blue, Color.Orange] }
+]
+
+// --- Sticker position lookup tables ---
+
+type StickerPos = { face: FaceCode; index: StickerIndex }
+
+const buildStickerPositionMaps = () => {
+  const cornerMap: Record<string, StickerPos[]> = {}
+  const edgeMap: Record<string, StickerPos[]> = {}
+  const faces: FaceCode[] = ['U', 'D', 'F', 'B', 'L', 'R']
+  const indices: StickerIndex[] = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+  for (const face of faces) {
+    for (const idx of indices) {
+      const info = stickerMapping[face][idx]
+      if (info.type === 'corner') {
+        if (!cornerMap[info.cornerId]) cornerMap[info.cornerId] = []
+        cornerMap[info.cornerId].push({ face, index: idx })
+      } else if (info.type === 'edge') {
+        if (!edgeMap[info.edgeId]) edgeMap[info.edgeId] = []
+        edgeMap[info.edgeId].push({ face, index: idx })
+      }
+    }
+  }
+
+  for (const [posId, positions] of Object.entries(cornerMap)) {
+    positions.sort((a, b) => posId.indexOf(a.face) - posId.indexOf(b.face))
+  }
+  for (const [posId, positions] of Object.entries(edgeMap)) {
+    positions.sort((a, b) => posId.indexOf(a.face) - posId.indexOf(b.face))
+  }
+
+  return {
+    corners: cornerMap as Record<CornerPositionId, [StickerPos, StickerPos, StickerPos]>,
+    edges: edgeMap as Record<EdgePositionId, [StickerPos, StickerPos]>
+  }
+}
+
+const STICKER_POSITIONS = buildStickerPositionMaps()
+
+// --- Piece lookup by sorted color key ---
+
+const sortedColorKey = (colors: readonly ColorCode[]): string => [...colors].sort().join(',')
+
+const CORNER_BY_COLORS = new Map(CORNER_DEFS.map(def => [sortedColorKey(def.colors), def]))
+
+const EDGE_BY_COLORS = new Map(EDGE_DEFS.map(def => [sortedColorKey(def.colors), def]))
+
+// --- Permutation parity ---
+
+const computeParity = <T extends string>(
+  positions: readonly T[],
+  pieces: Record<string, { id: T }>
+): number => {
+  const visited = new Set<T>()
+  let cycles = 0
+
+  for (const pos of positions) {
+    if (visited.has(pos)) continue
+    cycles++
+    let current = pos
+    while (!visited.has(current)) {
+      visited.add(current)
+      current = pieces[current].id
+    }
+  }
+
+  return (positions.length - cycles) % 2
+}
+
+// --- Main reconstruction ---
+
+export const reconstructState = (stickers: StickersByFace): ReconstructResult => {
+  const errors: string[] = []
+
+  // 1. Validate color counts (exactly 9 of each)
+  const allStickers = (['U', 'D', 'F', 'B', 'L', 'R'] as const).flatMap(f => stickers[f])
+  const colorCounts = new Map<ColorCode, number>()
+  for (const color of allStickers) {
+    colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1)
+  }
+
+  for (const code of Object.values(Color) as ColorCode[]) {
+    const count = colorCounts.get(code) ?? 0
+    if (count !== 9) {
+      errors.push(`Expected 9 ${colorName[code]} stickers, found ${count}`)
+    }
+  }
+  if (errors.length > 0) return { ok: false, errors }
+
+  // 2. Validate centers (each color exactly once)
+  const faces = ['U', 'D', 'F', 'B', 'L', 'R'] as const
+  const centers = {} as Record<FaceCode, ColorCode>
+  const centerColors = new Set<ColorCode>()
+  for (const face of faces) {
+    centers[face] = stickers[face][4]
+    centerColors.add(stickers[face][4])
+  }
+  if (centerColors.size !== 6) {
+    errors.push('Centers must have 6 different colors')
+    return { ok: false, errors }
+  }
+
+  // 3-5. Identify corner/edge pieces, check for duplicates, determine orientations
+  const cornerPositions = Object.keys(CornerPosition) as CornerPositionId[]
+  const reconstructedCorners = {} as Record<CornerPositionId, ReturnType<typeof makeCornerPiece>>
+  const cornerFirstPos = new Map<CornerPositionId, CornerPositionId>()
+
+  for (const pos of cornerPositions) {
+    const [sp0, sp1, sp2] = STICKER_POSITIONS.corners[pos]
+    const observed: [ColorCode, ColorCode, ColorCode] = [
+      stickers[sp0.face][sp0.index],
+      stickers[sp1.face][sp1.index],
+      stickers[sp2.face][sp2.index]
+    ]
+
+    const pieceDef = CORNER_BY_COLORS.get(sortedColorKey(observed))
+    if (!pieceDef) {
+      const names = observed.map(c => colorName[c]).join('-')
+      errors.push(`Invalid corner at ${pos}: ${names} is not a valid corner`)
+      continue
+    }
+
+    const prevPos = cornerFirstPos.get(pieceDef.id)
+    if (prevPos) {
+      const names = observed.map(c => colorName[c]).join('-')
+      errors.push(`Duplicate corner: ${names} appears at ${prevPos} and ${pos}`)
+      continue
+    }
+    cornerFirstPos.set(pieceDef.id, pos)
+
+    let orientation: CornerOrientation | null = null
+    for (const o of [0, 1, 2] as CornerOrientation[]) {
+      const matches = [0, 1, 2].every(
+        i => observed[i] === pieceDef.colors[cornerColorIndex(pieceDef.id, pos, i, o)]
+      )
+      if (matches) {
+        orientation = o
+        break
+      }
+    }
+
+    if (orientation === null) {
+      errors.push(`Cannot determine orientation for corner at ${pos}`)
+      continue
+    }
+
+    reconstructedCorners[pos] = makeCornerPiece(pieceDef.id, pos, pieceDef.colors, orientation)
+  }
+
+  // (continued) Identify edge pieces, check for duplicates, determine orientations
+  const edgePositions = Object.keys(EdgePosition) as EdgePositionId[]
+  const reconstructedEdges = {} as Record<EdgePositionId, ReturnType<typeof makeEdgePiece>>
+  const edgeFirstPos = new Map<EdgePositionId, EdgePositionId>()
+
+  for (const pos of edgePositions) {
+    const [sp0, sp1] = STICKER_POSITIONS.edges[pos]
+    const observed: [ColorCode, ColorCode] = [
+      stickers[sp0.face][sp0.index],
+      stickers[sp1.face][sp1.index]
+    ]
+
+    const pieceDef = EDGE_BY_COLORS.get(sortedColorKey(observed))
+    if (!pieceDef) {
+      const names = observed.map(c => colorName[c]).join('-')
+      errors.push(`Invalid edge at ${pos}: ${names} is not a valid edge`)
+      continue
+    }
+
+    const prevPos = edgeFirstPos.get(pieceDef.id)
+    if (prevPos) {
+      const names = observed.map(c => colorName[c]).join('-')
+      errors.push(`Duplicate edge: ${names} appears at ${prevPos} and ${pos}`)
+      continue
+    }
+    edgeFirstPos.set(pieceDef.id, pos)
+
+    // On face[0] of position, baseIndex=0, colorIndex=(0+o)%2=o → sticker = colors[o]
+    const orientation: EdgeOrientation = observed[0] === pieceDef.colors[0] ? 0 : 1
+
+    reconstructedEdges[pos] = makeEdgePiece(pieceDef.id, pos, pieceDef.colors, orientation)
+  }
+
+  if (errors.length > 0) return { ok: false, errors }
+
+  // 6. Corner orientation sum must be divisible by 3
+  const cornerOrientationSum = cornerPositions.reduce(
+    (sum, pos) => sum + reconstructedCorners[pos].orientation,
+    0
+  )
+  if (cornerOrientationSum % 3 !== 0) {
+    errors.push("Impossible state: corner orientations don't add up")
+  }
+
+  // 7. Edge orientation sum must be divisible by 2
+  const edgeOrientationSum = edgePositions.reduce(
+    (sum, pos) => sum + reconstructedEdges[pos].orientation,
+    0
+  )
+  if (edgeOrientationSum % 2 !== 0) {
+    errors.push("Impossible state: edge orientations don't add up")
+  }
+
+  // 8. Permutation parity must match
+  const cornerParity = computeParity(cornerPositions, reconstructedCorners)
+  const edgeParity = computeParity(edgePositions, reconstructedEdges)
+  if (cornerParity !== edgeParity) {
+    errors.push('Impossible state: edge/corner parity mismatch')
+  }
+
+  if (errors.length > 0) return { ok: false, errors }
+
+  return {
+    ok: true,
+    state: {
+      corners: reconstructedCorners,
+      edges: reconstructedEdges,
+      centers
+    }
+  }
+}

--- a/packages/cube-engine/src/domain/geometry.ts
+++ b/packages/cube-engine/src/domain/geometry.ts
@@ -86,6 +86,32 @@ export const stickerMapping: StickerMapping = {
 }
 
 /**
+ * Compute the color index for a corner sticker, accounting for the chirality
+ * difference between U-layer and D-layer corner naming conventions.
+ *
+ * U-layer names (UFR, ULF, URB, UBL) and D-layer names (DFR, DLF, DRB, DBL)
+ * list faces in opposite cyclic orders. Same-layer moves produce cyclic
+ * sticker permutations, but cross-layer moves produce transpositions that
+ * require separate handling.
+ */
+export const cornerColorIndex = (
+  pieceId: CornerPositionId,
+  positionId: CornerPositionId,
+  baseIndex: number,
+  orientation: number
+): number => {
+  const sameLayer = pieceId[0] === positionId[0]
+
+  if (sameLayer) {
+    return positionId[0] === 'U' ? (baseIndex + orientation) % 3 : (baseIndex - orientation + 3) % 3
+  }
+
+  const fixed = pieceId[0] === 'U' ? (3 - orientation) % 3 : orientation
+
+  return baseIndex === fixed ? baseIndex : 3 - baseIndex - fixed
+}
+
+/**
  * Given a piece ID and a face, return the index of that face in the piece ID.
  * For example, for corner piece "UFR" and face "F", it returns 1.
  *

--- a/packages/cube-engine/src/domain/index.ts
+++ b/packages/cube-engine/src/domain/index.ts
@@ -1,6 +1,6 @@
 export { Color, Face, CornerPosition, EdgePosition } from './constants'
 export type { StickerIndex, StickerMapping } from './geometry'
-export { stickerMapping, faceIndexInId } from './geometry'
+export { stickerMapping, cornerColorIndex, faceIndexInId } from './geometry'
 export { isColor, isFace, isCornerPosition, isEdgePosition } from './guards'
 export type {
   ColorCode,

--- a/packages/cube-engine/src/index.ts
+++ b/packages/cube-engine/src/index.ts
@@ -44,6 +44,9 @@ export { createSolvedState } from './application/use-cases/createSolvedState'
 export { applyMoves } from './application/use-cases/applyMoves'
 export { generateScramble } from './application/use-cases/generateScramble'
 export type { RandomSource } from './application/use-cases/generateScramble'
+export { reconstructState } from './application/use-cases/reconstructState'
+export type { ReconstructResult } from './application/use-cases/reconstructState'
+export { invertMove, invertMoves } from './application/use-cases/invertMoves'
 
 // Infrastructure
 export { toStickers } from './infrastructure/render/toStickers'

--- a/packages/cube-engine/src/infrastructure/render/toStickers.ts
+++ b/packages/cube-engine/src/infrastructure/render/toStickers.ts
@@ -1,38 +1,5 @@
-import type {
-  ColorCode,
-  CornerPositionId,
-  CubeState,
-  FaceCode,
-  StickerIndex,
-  StickerMapping
-} from '~/domain'
-import { stickerMapping, faceIndexInId } from '~/domain/geometry'
-
-/**
- * Compute the color index for a corner sticker, accounting for the chirality
- * difference between U-layer and D-layer corner naming conventions.
- *
- * U-layer names (UFR, ULF, URB, UBL) and D-layer names (DFR, DLF, DRB, DBL)
- * list faces in opposite cyclic orders. Same-layer moves produce cyclic
- * sticker permutations, but cross-layer moves produce transpositions that
- * require separate handling.
- */
-const cornerColorIndex = (
-  pieceId: CornerPositionId,
-  positionId: CornerPositionId,
-  baseIndex: number,
-  orientation: number
-): number => {
-  const sameLayer = pieceId[0] === positionId[0]
-
-  if (sameLayer) {
-    return positionId[0] === 'U' ? (baseIndex + orientation) % 3 : (baseIndex - orientation + 3) % 3
-  }
-
-  const fixed = pieceId[0] === 'U' ? (3 - orientation) % 3 : orientation
-
-  return baseIndex === fixed ? baseIndex : 3 - baseIndex - fixed
-}
+import type { ColorCode, CubeState, FaceCode, StickerIndex, StickerMapping } from '~/domain'
+import { stickerMapping, cornerColorIndex, faceIndexInId } from '~/domain/geometry'
 
 export type StickersByFace = Record<FaceCode, ColorCode[]>
 


### PR DESCRIPTION
## Summary

- Add `reconstructState` use case to cube-engine: converts 54 sticker colors back to CubeState with 8-step validation (color counts, centers, piece identification, duplicates, orientation sums, permutation parity)
- Add `invertMove`/`invertMoves` utilities to cube-engine for move sequence reversal
- Extract `cornerColorIndex` to shared geometry module (was duplicated in toStickers)
- Extract `faceNameByCode` to shared colors lib (was duplicated in FaceGrid)
- Add solver feature with interactive input UI: ColorPalette, InteractiveFaceGrid, InteractiveCubeNet components + nanostores-based solver store
- Replace Solver page placeholder with full input assembly: paint stickers, real-time validation, Reset/Scramble/Solve buttons

## Test Plan

- [x] Engine: reconstructState round-trips with toStickers for solved and scrambled states
- [x] Engine: reconstructState catches all 5 error categories (counts, invalid pieces, duplicates, orientation, parity)
- [x] Engine: invertMoves produces identity when applied after original moves
- [x] Web: ColorPalette renders 6 swatches, highlights selected, fires callback
- [x] Web: InteractiveFaceGrid renders 9 buttons, center disabled, click-to-paint works
- [x] Web: InteractiveCubeNet renders all 6 faces with correct layout
- [x] Web: Solver page shows validation errors, enables Solve after scramble, resets correctly
- [x] All 4 checks pass: test (283), typecheck, lint, format