### PR TITLE
refactor(cube-engine): extract shared applySeq into teaching helpers

### DIFF
--- a/packages/cube-engine/src/application/teaching/helpers.ts
+++ b/packages/cube-engine/src/application/teaching/helpers.ts
@@ -1,5 +1,6 @@
 import type { ColorCode, CornerPositionId, CubeState, EdgePositionId, MoveToken } from '~/domain'
 import { CornerPosition, EdgePosition } from '~/domain/constants'
+import { applyMove } from '~/domain/moves/apply'
 
 // Pure local helpers for the teaching solver — kept here (not imported from
 // solver/helpers) so the teaching module stays independent of Solver mode.
@@ -43,3 +44,9 @@ export const isEdgeHome = (state: CubeState, pos: EdgePositionId): boolean =>
 // Invert a run of U turns (for the closing "restore" placement). Pure on U tokens.
 export const invertUTurns = (moves: readonly MoveToken[]): MoveToken[] =>
   moves.map(m => (m === 'U' ? "U'" : m === "U'" ? 'U' : 'U2'))
+
+export const applySeq = (state: CubeState, moves: readonly MoveToken[]): CubeState => {
+  let s = state
+  for (const m of moves) s = applyMove(s, m)
+  return s
+}

--- a/packages/cube-engine/src/application/teaching/planLastLayer.ts
+++ b/packages/cube-engine/src/application/teaching/planLastLayer.ts
@@ -1,7 +1,7 @@
 import type { CornerPositionId, CubeState, EdgePositionId, MoveToken } from '~/domain'
 import { getAlgorithm } from '~/domain'
-import { applyMove } from '~/domain/moves/apply'
 
+import { applySeq } from './helpers'
 import type { TeachingPlan, TeachingSegment, TeachingStepGroup } from './types'
 
 // Last-layer teaching planners (Ch5 orient corners, Ch6 place corners, Ch7 permute
@@ -14,12 +14,6 @@ import type { TeachingPlan, TeachingSegment, TeachingStepGroup } from './types'
 const D_CORNERS: readonly CornerPositionId[] = ['DFR', 'DRB', 'DBL', 'DLF']
 const D_EDGES: readonly EdgePositionId[] = ['DF', 'DR', 'DB', 'DL']
 const D_ROT: readonly MoveToken[][] = [[], ['D'], ['D2'], ["D'"]]
-
-const applySeq = (state: CubeState, moves: readonly MoveToken[]): CubeState => {
-  let s = state
-  for (const m of moves) s = applyMove(s, m)
-  return s
-}
 
 export const allDEdgesOriented = (s: CubeState): boolean =>
   D_EDGES.every(p => s.edges[p].orientation === 0)

--- a/packages/cube-engine/src/application/teaching/planSecondLayer.ts
+++ b/packages/cube-engine/src/application/teaching/planSecondLayer.ts
@@ -1,8 +1,7 @@
 import type { ColorCode, CubeState, EdgePositionId, MoveToken } from '~/domain'
 import { Color, getAlgorithm } from '~/domain'
-import { applyMove } from '~/domain/moves/apply'
 
-import { findEdgeByColors, isEdgeHome } from './helpers'
+import { applySeq, findEdgeByColors, isEdgeHome } from './helpers'
 import type { TeachingPlan, TeachingSegment, TeachingStepGroup } from './types'
 
 // planSecondLayer (Ch3) — complete the middle layer. Taught as TWO gestures, the
@@ -73,12 +72,6 @@ const dAlign = (from: EdgePositionId, to: EdgePositionId): MoveToken[] => {
   if (steps === 1) return ['D']
   if (steps === 2) return ['D2']
   return ["D'"]
-}
-
-const applySeq = (state: CubeState, moves: readonly MoveToken[]): CubeState => {
-  let s = state
-  for (const m of moves) s = applyMove(s, m)
-  return s
 }
 
 // One edge's worth of work: optionally evict a wrong middle edge, align on D, insert.

--- a/packages/cube-engine/src/application/teaching/planWhiteCorners.ts
+++ b/packages/cube-engine/src/application/teaching/planWhiteCorners.ts
@@ -1,8 +1,7 @@
 import type { ColorCode, CornerPositionId, CubeState, MoveToken } from '~/domain'
 import { getAlgorithm } from '~/domain'
-import { applyMove } from '~/domain/moves/apply'
 
-import { findCornerByColors, invertUTurns, isCornerHome } from './helpers'
+import { applySeq, findCornerByColors, invertUTurns, isCornerHome } from './helpers'
 import type { TeachingPlan, TeachingSegment, TeachingStepGroup } from './types'
 
 // planWhiteCorners (Ch2) — the proof-slice planner. Turns a white-cross state into
@@ -68,12 +67,6 @@ const uSetupTo = (from: CornerPositionId, to: CornerPositionId): MoveToken[] =>
   ringTurn(U_ORDER, 'U', from, to)
 const dSetupTo = (from: CornerPositionId, to: CornerPositionId): MoveToken[] =>
   ringTurn(D_ORDER, 'D', from, to)
-
-const applySeq = (state: CubeState, moves: readonly MoveToken[]): CubeState => {
-  let s = state
-  for (const m of moves) s = applyMove(s, m)
-  return s
-}
 
 const cornerColors = (
   solved: CubeState,


### PR DESCRIPTION
Move the identical `applySeq` helper from `planWhiteCorners.ts`, `planSecondLayer.ts`, and `planLastLayer.ts` into the shared `helpers.ts` with `readonly MoveToken[]` as the canonical signature. No logic changes — pure extraction.

Closes #21

Generated with [Claude Code](https://claude.ai/code)