### PR TITLE
fix(web): decode percent-encoded route params in matchRoute

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -14,7 +14,6 @@ export default [
   {
     languageOptions: {
       parserOptions: {
-        project: './tsconfig.json',
         tsconfigRootDir: __dirname
       }
     }

--- a/apps/web/src/lib/router.spec.tsx
+++ b/apps/web/src/lib/router.spec.tsx
@@ -135,22 +135,22 @@ describe('navigate', () => {
 })
 
 describe('matchRoute', () => {
-  const render = (): null => null
+  const renderNull = (): null => null
 
   it('decodes a percent-encoded dynamic param so white%2Dcross matches white-cross', () => {
-    const result = matchRoute({ '/coach/:id': render }, '/coach/white%2Dcross')
+    const result = matchRoute({ '/coach/:id': renderNull }, '/coach/white%2Dcross')
     expect(result).not.toBeNull()
     expect(result?.params).toEqual({ id: 'white-cross' })
   })
 
   it('leaves an already-decoded param unchanged', () => {
-    const result = matchRoute({ '/coach/:id': render }, '/coach/white-cross')
+    const result = matchRoute({ '/coach/:id': renderNull }, '/coach/white-cross')
     expect(result).not.toBeNull()
     expect(result?.params).toEqual({ id: 'white-cross' })
   })
 
   it('returns null for a malformed percent-encoded param without throwing', () => {
-    const result = matchRoute({ '/coach/:id': render }, '/coach/%E0%A4')
+    const result = matchRoute({ '/coach/:id': renderNull }, '/coach/%E0%A4')
     expect(result).toBeNull()
   })
 })

--- a/apps/web/src/lib/router.spec.tsx
+++ b/apps/web/src/lib/router.spec.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 
-import { Link, Router, navigate } from '~/lib/router'
+import { Link, Router, matchRoute, navigate } from '~/lib/router'
 
 const TestHome = () => <div>Home Page</div>
 const TestAbout = () => <div>About Page</div>
@@ -131,5 +131,21 @@ describe('navigate', () => {
   it('should not navigate when already on target path', () => {
     navigate('/')
     expect(window.location.pathname).toBe('/')
+  })
+})
+
+describe('matchRoute', () => {
+  const render = (): null => null
+
+  it('decodes a percent-encoded dynamic param so white%2Dcross matches white-cross', () => {
+    const result = matchRoute({ '/coach/:id': render }, '/coach/white%2Dcross')
+    expect(result).not.toBeNull()
+    expect(result?.params).toEqual({ id: 'white-cross' })
+  })
+
+  it('leaves an already-decoded param unchanged', () => {
+    const result = matchRoute({ '/coach/:id': render }, '/coach/white-cross')
+    expect(result).not.toBeNull()
+    expect(result?.params).toEqual({ id: 'white-cross' })
   })
 })

--- a/apps/web/src/lib/router.spec.tsx
+++ b/apps/web/src/lib/router.spec.tsx
@@ -148,4 +148,9 @@ describe('matchRoute', () => {
     expect(result).not.toBeNull()
     expect(result?.params).toEqual({ id: 'white-cross' })
   })
+
+  it('returns null for a malformed percent-encoded param without throwing', () => {
+    const result = matchRoute({ '/coach/:id': render }, '/coach/%E0%A4')
+    expect(result).toBeNull()
+  })
 })

--- a/apps/web/src/lib/router.tsx
+++ b/apps/web/src/lib/router.tsx
@@ -40,7 +40,8 @@ export const matchRoute = (
         try {
           params[expected.slice(1)] = decodeURIComponent(actual)
         } catch {
-          return null
+          matched = false
+          break
         }
       } else if (expected !== actual) {
         matched = false

--- a/apps/web/src/lib/router.tsx
+++ b/apps/web/src/lib/router.tsx
@@ -11,7 +11,7 @@ const normalizePath = (pathname: string): string =>
 
 // Resolve a path against the route map: exact static routes win first, then a
 // single-segment `:param` pattern pass. Returns null when nothing matches.
-const matchRoute = (
+export const matchRoute = (
   routes: RouteMap,
   pathname: string
 ): { render: RouteRender; params: RouteParams } | null => {
@@ -37,7 +37,7 @@ const matchRoute = (
           matched = false
           break
         }
-        params[expected.slice(1)] = actual
+        params[expected.slice(1)] = decodeURIComponent(actual)
       } else if (expected !== actual) {
         matched = false
         break

--- a/apps/web/src/lib/router.tsx
+++ b/apps/web/src/lib/router.tsx
@@ -37,7 +37,11 @@ export const matchRoute = (
           matched = false
           break
         }
-        params[expected.slice(1)] = decodeURIComponent(actual)
+        try {
+          params[expected.slice(1)] = decodeURIComponent(actual)
+        } catch {
+          return null
+        }
       } else if (expected !== actual) {
         matched = false
         break


### PR DESCRIPTION
Applies `decodeURIComponent()` to each dynamic segment value in `matchRoute` so URLs like `/coach/white%2Dcross` correctly match lesson id `white-cross` instead of silently rendering LessonNotFound.

Also exports `matchRoute` for direct testing, adds two tests covering percent-encoded and plain params, and fixes a pre-existing ESLint failure in `router.spec.tsx` caused by the web ESLint config overriding the shared base's `project: true` (project service mode) with `project: './tsconfig.json'` (legacy program mode).

Closes #20

Generated with [Claude Code](https://claude.ai/code)