### PR TITLE
docs(web): warn on destructive version bump without migrate

### DIFF
--- a/apps/web/src/features/coach/stores/coachStore.ts
+++ b/apps/web/src/features/coach/stores/coachStore.ts
@@ -77,6 +77,9 @@ export const parseCoachProgress = (data: unknown): CoachProgress | null => {
   }
 }
 
+// Bumping version without a migrate function is a silent destructive reset —
+// all stored progress is lost. Always provide a migrate function or document
+// the intentional reset in a changelog entry.
 const progressStorage = createVersionedStorage<CoachProgress>({
   key: PROGRESS_KEY,
   version: 1,

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -57,7 +57,7 @@ export const createVersionedStorage = <T>(
         return migrated === null ? fallback : migrated
       }
 
-      if (parsed.version < version && !migrate) {
+      if (parsed.version < version && !migrate && import.meta.env.DEV) {
         console.warn(
           `[storage] ${key}: version bumped ${parsed.version}→${version} without a migrate function — stored data discarded. Provide migrate or document this as an intentional reset.`
         )

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -57,7 +57,7 @@ export const createVersionedStorage = <T>(
         return migrated === null ? fallback : migrated
       }
 
-      if (parsed.version < version && !migrate && import.meta.env.DEV) {
+      if (parsed.version < version && !migrate && import.meta.env?.DEV) {
         console.warn(
           `[storage] ${key}: version bumped ${parsed.version}→${version} without a migrate function — stored data discarded. Provide migrate or document this as an intentional reset.`
         )

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -57,6 +57,12 @@ export const createVersionedStorage = <T>(
         return migrated === null ? fallback : migrated
       }
 
+      if (parsed.version < version && !migrate) {
+        console.warn(
+          `[storage] ${key}: version bumped ${parsed.version}→${version} without a migrate function — stored data discarded. Provide migrate or document this as an intentional reset.`
+        )
+      }
+
       return fallback
     } catch {
       return fallback


### PR DESCRIPTION
Add a `console.warn` in `storage.ts` when a stored version is older than the current version and no `migrate` function was provided, making the silent data-wipe path visible during development.

Add a comment above the `createVersionedStorage` call in `coachStore.ts` reminding future developers that bumping version without a migrate function discards all stored progress.

Closes #19

Generated with [Claude Code](https://claude.ai/code)