### PR TITLE
fix(coach): batch 1 — post-review P1 reliability fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,16 +18,17 @@
     "clean": "rm -rf node_modules coverage dist .turbo"
   },
   "dependencies": {
+    "@hono/node-server": "^1.14.2",
     "@hookform/resolvers": "^5.2.2",
     "@nanostores/react": "^1.1.0",
     "@packages/cube-engine": "workspace:*",
     "daisyui": "^5.5.19",
-    "@hono/node-server": "^1.14.2",
     "hono": "^4.7.10",
     "lucide-react": "^0.525.0",
     "nanostores": "^1.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-error-boundary": "^6.1.2",
     "react-hook-form": "^7.72.1",
     "zod": "^4.3.6"
   },

--- a/apps/web/src/features/coach/components/CoachErrorBoundary.spec.tsx
+++ b/apps/web/src/features/coach/components/CoachErrorBoundary.spec.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { CoachErrorBoundary } from '~/features/coach/components/CoachErrorBoundary'
+
+// React logs caught render errors to console.error; silence it so the boundary's
+// expected throws don't clutter the test output.
+let errorSpy: ReturnType<typeof spyOn>
+beforeEach(() => {
+  errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  errorSpy.mockRestore()
+  cleanup()
+})
+
+const Boom = (): never => {
+  throw new Error('planner regression')
+}
+
+describe('CoachErrorBoundary', () => {
+  it('should render the recovery fallback when a child throws, not a blank screen', () => {
+    render(
+      <CoachErrorBoundary resetKey='white-cross'>
+        <Boom />
+      </CoachErrorBoundary>
+    )
+    expect(screen.getByRole('heading', { name: 'Une erreur est survenue' })).toBeDefined()
+    expect(screen.getByRole('link', { name: 'Retour au Coach' })).toBeDefined()
+  })
+
+  it('should render its children untouched when they do not throw', () => {
+    render(
+      <CoachErrorBoundary resetKey='white-cross'>
+        <p>chapitre ok</p>
+      </CoachErrorBoundary>
+    )
+    expect(screen.getByText('chapitre ok')).toBeDefined()
+  })
+
+  it('should reset on lesson change so navigating away clears a stuck error', () => {
+    const { rerender } = render(
+      <CoachErrorBoundary resetKey='white-cross'>
+        <Boom />
+      </CoachErrorBoundary>
+    )
+    expect(screen.getByRole('heading', { name: 'Une erreur est survenue' })).toBeDefined()
+
+    rerender(
+      <CoachErrorBoundary resetKey='coach-home'>
+        <p>chapitre ok</p>
+      </CoachErrorBoundary>
+    )
+    expect(screen.getByText('chapitre ok')).toBeDefined()
+  })
+})

--- a/apps/web/src/features/coach/components/CoachErrorBoundary.tsx
+++ b/apps/web/src/features/coach/components/CoachErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import type { FallbackProps } from 'react-error-boundary'
+
+import { Link } from '~/lib/router'
+
+// Coach's last line of defence. The teaching planners throw deliberately when a plan
+// is incomplete, and `resolveRecipe` throws on out-of-range lesson data — but the
+// call chain runs inside `useStore($stepRecipe)` at render time, and nanostores'
+// `computed` does not catch callback throws. Without a boundary, any such throw blanks
+// the entire SPA. This contains the failure to the Coach route and gives the learner a
+// way out, mirroring the Solver's `$solveError` recovery UI.
+const CoachErrorFallback = ({ resetErrorBoundary }: FallbackProps) => (
+  <section className='flex flex-col items-start gap-4' aria-label='Erreur du Coach'>
+    <h1 className='text-cube-green-text text-2xl font-bold'>Une erreur est survenue</h1>
+    <p className='text-base-content/70'>
+      Ce chapitre n’a pas pu se charger. Reviens au Coach ou réessaie.
+    </p>
+    <div className='flex items-center gap-2'>
+      <button type='button' className='btn btn-soft cursor-pointer' onClick={resetErrorBoundary}>
+        Réessayer
+      </button>
+      <Link to='/coach' className='btn bg-cube-green text-cube-green-content cursor-pointer'>
+        Retour au Coach
+      </Link>
+    </div>
+  </section>
+)
+
+// `resetKey` (the current lessonId) resets the boundary on navigation, so opening
+// another chapter clears a stuck error without the learner pressing Réessayer.
+export const CoachErrorBoundary = ({
+  resetKey,
+  children
+}: {
+  resetKey?: string
+  children: ReactNode
+}) => (
+  <ErrorBoundary FallbackComponent={CoachErrorFallback} resetKeys={[resetKey]}>
+    {children}
+  </ErrorBoundary>
+)

--- a/apps/web/src/features/coach/components/LessonPlayer.spec.tsx
+++ b/apps/web/src/features/coach/components/LessonPlayer.spec.tsx
@@ -70,6 +70,20 @@ describe('LessonPlayer', () => {
     expect($progress.get().completedLessons).toContain('white-cross')
   })
 
+  it('should not mark a shorter incoming chapter complete from the previous chapter step index', async () => {
+    const user = userEvent.setup()
+    // white-corners has 8 steps (last index 7); finish has 3 (last index 2).
+    const { rerender } = render(<LessonPlayer lessonId='white-corners' />)
+    await user.click(screen.getByLabelText(/^Étape 8 :/))
+
+    // Navigating to the shorter chapter must not auto-complete it before its first view.
+    rerender(<LessonPlayer lessonId='finish' />)
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'La dernière ligne droite' })).toBeDefined()
+    })
+    expect($progress.get().completedLessons).not.toContain('finish')
+  })
+
   it('should render a not-found state for an unknown lesson id', () => {
     render(<LessonPlayer lessonId='does-not-exist' />)
     expect(screen.getByText('Leçon introuvable')).toBeDefined()

--- a/apps/web/src/features/coach/components/LessonPlayer.tsx
+++ b/apps/web/src/features/coach/components/LessonPlayer.tsx
@@ -12,6 +12,8 @@ import type {
   UnderstandStep
 } from '~/features/coach/data/types'
 import {
+  $currentLessonId,
+  $lessonStepIndex,
   applyInteractiveMove,
   applyPracticeMove,
   goToStep,
@@ -263,8 +265,16 @@ export const LessonPlayer = ({ lessonId }: { lessonId: string }) => {
 
   // Reaching the last step *is* finishing the chapter — mark it complete here so
   // the player needs no dedicated "terminer" button (P4 chrome note). Idempotent.
+  //
+  // On a `lessonId` change this effect and the startLesson effect re-run in the same
+  // commit, with the *previous* chapter's step index still captured by `stepIndex`.
+  // Reading the store live — startLesson runs first, resetting both atoms to the new
+  // chapter — stops a shorter incoming chapter from being marked complete on arrival
+  // (e.g. leaving white-corners at step 7 then opening finish, whose last index is 2).
   useEffect(() => {
-    if (lesson && stepIndex >= lesson.steps.length - 1) markLessonComplete(lessonId)
+    if ($currentLessonId.get() !== lessonId) return
+    const liveStep = $lessonStepIndex.get()
+    if (lesson && liveStep >= lesson.steps.length - 1) markLessonComplete(lessonId)
   }, [lesson, lessonId, stepIndex])
 
   if (!lesson) return <LessonNotFound />

--- a/apps/web/src/features/coach/components/index.ts
+++ b/apps/web/src/features/coach/components/index.ts
@@ -1,3 +1,4 @@
+export { CoachErrorBoundary } from './CoachErrorBoundary'
 export { DemoControls } from './DemoControls'
 export { LessonBrowser } from './LessonBrowser'
 export { LessonPlayer } from './LessonPlayer'

--- a/apps/web/src/features/coach/data/illustrative.ts
+++ b/apps/web/src/features/coach/data/illustrative.ts
@@ -59,7 +59,33 @@ let cache: Milestones | null = null
 const advance = (from: CubeState, plan: ReturnType<typeof planSecondLayer>): CubeState =>
   applyMoves(from, [...flattenTeachingPlan(plan)])
 
+// Last-resort milestones if the chained solve/planner computation throws — every
+// chapter falls back to a solved cube. A wrong (but valid) cube degrades the
+// illustrative visuals; it does not crash the Coach route. Each field is its own
+// state so nothing is shared by reference.
+const fallbackMilestones = (): Milestones => ({
+  whiteCrossOnly: createSolvedState(),
+  crossMisaligned: createSolvedState(),
+  whiteCorners: createSolvedState(),
+  secondLayer: createSolvedState(),
+  yellowCross: createSolvedState(),
+  yellowCornersOriented: createSolvedState(),
+  yellowCornersPlaced: createSolvedState()
+})
+
 const compute = (): Milestones => {
+  try {
+    return computeMilestones()
+  } catch (err) {
+    // The fixed scramble is deterministic and tested, so this only fires on a future
+    // solver/planner regression. Degrade to solved cubes (cached, so no rethrow loop)
+    // rather than permanently breaking every lesson open until a page refresh.
+    console.error('illustrative: milestone computation failed; falling back to solved cubes', err)
+    return fallbackMilestones()
+  }
+}
+
+const computeMilestones = (): Milestones => {
   const scrambled = applyMoves(createSolvedState(), FIXED_SCRAMBLE)
   const solution = solveCube(scrambled)
   // Only the white cross comes from the shared solver (Ch1 is untouched legacy). Every

--- a/apps/web/src/features/coach/data/lessons.spec.ts
+++ b/apps/web/src/features/coach/data/lessons.spec.ts
@@ -2,7 +2,13 @@ import { getAlgorithm } from '@packages/cube-engine'
 import { describe, expect, it } from 'bun:test'
 
 import { LESSONS } from '~/features/coach/data/lessons'
-import { stepAlgorithmId, stepCatalogIds, stepScenario } from '~/features/coach/data/types'
+import {
+  isTeachingDemo,
+  stepAlgorithmId,
+  stepCatalogIds,
+  stepScenario
+} from '~/features/coach/data/types'
+import { runTeachingPlan } from '~/features/coach/stores/coachStore'
 
 // The named states a teaching scenario may travel — the milestones the store can
 // resolve. A scenario naming anything else would render a blank cube. (PD-4)
@@ -64,6 +70,21 @@ describe('lesson registry', () => {
           expect(KNOWN_TEACHING_PHASES.has(scenario.phase)).toBe(true)
           expect(KNOWN_MILESTONES.has(scenario.from)).toBe(true)
           expect(KNOWN_MILESTONES.has(scenario.to)).toBe(true)
+        }
+      }
+    }
+  })
+
+  // A teaching demo plays group `groupIndex` of its scenario's plan. An out-of-range
+  // index used to silently render a 0-move demo with no way out; resolveRecipe now
+  // throws on it, so this asserts the data never triggers that throw in the first place.
+  it('should keep every teaching demo groupIndex within its plan group count', () => {
+    for (const lesson of LESSONS) {
+      for (const step of lesson.steps) {
+        if (step.kind === 'demo' && isTeachingDemo(step)) {
+          const plan = runTeachingPlan(step.scenario)
+          expect(step.groupIndex).toBeGreaterThanOrEqual(0)
+          expect(step.groupIndex).toBeLessThan(plan.groups.length)
         }
       }
     }

--- a/apps/web/src/features/coach/index.ts
+++ b/apps/web/src/features/coach/index.ts
@@ -1,4 +1,4 @@
-export { LessonBrowser, LessonPlayer } from './components'
+export { CoachErrorBoundary, LessonBrowser, LessonPlayer } from './components'
 export { LESSONS, getLesson } from './data/lessons'
 export type { Lesson, LessonStep } from './data/types'
 export { stepAlgorithmId } from './data/types'

--- a/apps/web/src/features/coach/stores/coachStore.ts
+++ b/apps/web/src/features/coach/stores/coachStore.ts
@@ -132,7 +132,9 @@ export const $currentStep = computed(
 // Run a teaching scenario's planner on its `from` milestone. The single source of
 // the moves a teaching demo / chapter practice replays — the engine, never inline
 // data (NFR-004). Phase 37 extends the switch with the remaining last-layer phases.
-const runTeachingPlan = (scenario: TeachingScenario) => {
+// Exported so lesson data can be checked against the *actual* plan it produces
+// (every teaching demo's groupIndex must address a real group — see lessons.spec).
+export const runTeachingPlan = (scenario: TeachingScenario) => {
   const start = namedState(scenario.from)
   if (scenario.phase === 'white-corners') return planWhiteCorners(start, createSolvedState())
   if (scenario.phase === 'second-layer') return planSecondLayer(start)
@@ -189,7 +191,16 @@ const resolveRecipe = (step: LessonStep | null): StepRecipe => {
     const plan = runTeachingPlan(step.scenario)
     const before = plan.groups.slice(0, step.groupIndex)
     const group = plan.groups[step.groupIndex]
-    const segments = group?.segments ?? []
+    // Fail loudly rather than render a silent 0-move demo with no way out: an
+    // out-of-range groupIndex is a lesson-data bug (lessons.spec guards against it
+    // shipping). At runtime the Coach ErrorBoundary catches this and offers recovery.
+    if (!group) {
+      throw new Error(
+        `Coach: demo groupIndex ${step.groupIndex} is out of range for teaching phase ` +
+          `"${step.scenario.phase}" (${plan.groups.length} group(s))`
+      )
+    }
+    const segments = group.segments
     return {
       moves: segments.flatMap(segment => [...segment.moves]),
       base: applyMoves(

--- a/apps/web/src/pages/Coach.tsx
+++ b/apps/web/src/pages/Coach.tsx
@@ -1,7 +1,7 @@
-import { LessonBrowser, LessonPlayer } from '~/features/coach'
+import { CoachErrorBoundary, LessonBrowser, LessonPlayer } from '~/features/coach'
 
-export const Coach = ({ lessonId }: { lessonId?: string }) => {
-  if (lessonId) return <LessonPlayer lessonId={lessonId} />
-
-  return <LessonBrowser />
-}
+export const Coach = ({ lessonId }: { lessonId?: string }) => (
+  <CoachErrorBoundary resetKey={lessonId}>
+    {lessonId ? <LessonPlayer lessonId={lessonId} /> : <LessonBrowser />}
+  </CoachErrorBoundary>
+)

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "nanostores": "^1.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-error-boundary": "^6.1.2",
         "react-hook-form": "^7.72.1",
         "zod": "^4.3.6",
       },
@@ -1253,6 +1254,8 @@
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-error-boundary": ["react-error-boundary@6.1.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng=="],
 
     "react-hook-form": ["react-hook-form@7.72.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig=="],
 


### PR DESCRIPTION
## What

Batch 1 of the Coach v1 post-review issues — the four **P1** reliability/correctness findings from the `ce-code-review` on PR #11. Each is a small, self-contained fix with a test where the path is reachable.

| Issue | Fix |
|-------|-----|
| **#12** | `resolveRecipe` silently returned an empty recipe for an out-of-range demo `groupIndex` (0-move demo, no way out). Now throws a descriptive error; `lessons.spec` asserts every demo `groupIndex` addresses a real group, so it can't fire from shipped data. |
| **#13** | No error boundary anywhere — a render-time throw blanked the whole SPA. Added a `react-error-boundary` around the Coach route with a French recovery fallback that resets on lesson change. |
| **#14** | A `lessonId` change re-ran the completion effect with the previous chapter's stale step index, auto-completing a shorter incoming chapter before its first view. Guarded on the live store. |
| **#15** | `illustrative.compute()` ran the planners unguarded and memoised the result; a throw left the cache null and rethrew forever. Now degrades to solved-cube milestones on failure. |

## Design note — #12 + #13 coexist deliberately

The two findings appear to conflict (#12 wants a throw, #13 suggested swallowing throws into `EMPTY_RECIPE`). Swallowing would reintroduce the silent dead-end #12 fights. Instead: the guard **throws loudly**, and the **ErrorBoundary** catches it at render and offers recovery — loud *and* recoverable, no silent empty cube.

## Verification

`format:check`, `lint:check`, `typecheck`, `test` (296 pass), `build` — all green locally.

> Note: the pre-push hook tripped once on the known-flaky Solver timeout test (`Solver — solution view`, unrelated to this branch); it passes 296/0 when the web suite runs on its own.

Closes #12, #13, #14, #15